### PR TITLE
feat: add org context middleware and tRPC integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,15 @@
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
+        "@tanstack/react-query": "^5.90.20",
+        "@trpc/client": "^11.10.0",
+        "@trpc/react-query": "^11.10.0",
+        "@trpc/server": "^11.10.0",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "superjson": "^2.2.6",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1607,6 +1613,73 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@trpc/client": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.10.0.tgz",
+      "integrity": "sha512-h0s2AwDtuhS8INRb4hlo4z3RKCkarWqlOy+3ffJgrlDxzzW6aLUN+9nDrcN4huPje1Em15tbCOqhIc6oaKYTRw==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@trpc/server": "11.10.0",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/react-query": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@trpc/react-query/-/react-query-11.10.0.tgz",
+      "integrity": "sha512-SKLpwEMU32mpDTCc3msMxb0fx113x4Jsiw0/t+ENY6AtyvhvDMRF1bpWtoNyY6zpX5wN4JCQMhHef8k0T1rJIw==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.80.3",
+        "@trpc/client": "11.10.0",
+        "@trpc/server": "11.10.0",
+        "react": ">=18.2.0",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/server": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.10.0.tgz",
+      "integrity": "sha512-zZjTrR6He61e5TiT7e/bQqab/jRcXBZM8Fg78Yoo8uh5pz60dzzbYuONNUCOkafv5ppXVMms4NHYfNZgzw50vg==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.7.2"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2729,6 +2802,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/cross-spawn": {
@@ -4487,6 +4575,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -6122,6 +6222,18 @@
         }
       }
     },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6370,7 +6482,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6665,7 +6776,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,15 @@
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
+    "@tanstack/react-query": "^5.90.20",
+    "@trpc/client": "^11.10.0",
+    "@trpc/react-query": "^11.10.0",
+    "@trpc/server": "^11.10.0",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "superjson": "^2.2.6",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,13 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { appRouter } from '@/server/routers/_app';
+import { createTRPCContext } from '@/server/trpc';
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: createTRPCContext,
+  });
+
+export { handler as GET, handler as POST };

--- a/src/lib/orgContext.ts
+++ b/src/lib/orgContext.ts
@@ -1,0 +1,83 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { TRPCError } from '@trpc/server';
+import { OrgMember, OrgRole } from '@/types/database';
+
+export interface OrgContext {
+  orgId: string;
+  role: OrgRole;
+}
+
+// Simple in-memory cache for org context: userId -> { data, expiry }
+const orgContextCache = new Map<string, { data: OrgContext; expiry: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Derives org context from user's membership in org_members table.
+ * Returns the user's orgId and role within that org.
+ * Throws FORBIDDEN if the user has no org membership.
+ */
+export async function getOrgContext(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any>,
+  userId: string
+): Promise<OrgContext> {
+  // Check cache first
+  const cached = orgContextCache.get(userId);
+  if (cached && cached.expiry > Date.now()) {
+    return cached.data;
+  }
+
+  // Query org_members to find user's org membership
+  const { data: membership, error } = await supabase
+    .from('org_members')
+    .select('*')
+    .eq('user_id', userId)
+    .limit(1)
+    .single<OrgMember>();
+
+  if (error || !membership) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'User is not a member of any organization',
+    });
+  }
+
+  const orgContext: OrgContext = {
+    orgId: membership.org_id,
+    role: membership.role,
+  };
+
+  // Cache the result
+  orgContextCache.set(userId, {
+    data: orgContext,
+    expiry: Date.now() + CACHE_TTL_MS,
+  });
+
+  return orgContext;
+}
+
+/**
+ * Sets the PostgreSQL session variable for RLS org isolation.
+ * Must be called within a transaction or at the start of a request.
+ */
+export async function setOrgSessionVar(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any>,
+  orgId: string
+): Promise<void> {
+  const { error } = await supabase.rpc('set_org_context', {
+    org_id: orgId,
+  });
+
+  if (error) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: `Failed to set org context: ${error.message}`,
+    });
+  }
+}
+
+/** Clears cached org context for a user (e.g., on role change) */
+export function clearOrgContextCache(userId: string): void {
+  orgContextCache.delete(userId);
+}

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -1,0 +1,99 @@
+/**
+ * Root tRPC router.
+ *
+ * All sub-routers are merged here. The org context middleware is
+ * applied via orgProcedure, so all org-scoped queries automatically
+ * have app.current_org_id set for RLS enforcement.
+ */
+import { z } from 'zod';
+import { router, publicProcedure, authedProcedure, orgProcedure } from '../trpc';
+
+export const appRouter = router({
+  /** Health check — public, no auth required */
+  health: publicProcedure.query(() => {
+    return { status: 'ok', timestamp: new Date().toISOString() };
+  }),
+
+  /** Get current authenticated user info */
+  me: authedProcedure.query(async ({ ctx }) => {
+    const { data: profile } = await ctx.supabase
+      .from('users')
+      .select('*')
+      .eq('id', ctx.user.id)
+      .single();
+
+    return { user: profile };
+  }),
+
+  /** Organization-scoped routes */
+  org: router({
+    /** Get the current user's organization */
+    get: orgProcedure.query(async ({ ctx }) => {
+      const { data: org } = await ctx.supabase
+        .from('organizations')
+        .select('*')
+        .eq('id', ctx.orgId)
+        .single();
+
+      return { org, role: ctx.orgRole };
+    }),
+
+    /** List members in the current organization */
+    members: orgProcedure.query(async ({ ctx }) => {
+      const { data: members } = await ctx.supabase
+        .from('org_members')
+        .select('*, user:users(*)')
+        .eq('org_id', ctx.orgId);
+
+      return { members: members ?? [] };
+    }),
+  }),
+
+  /** Shift routes (org-scoped) */
+  shift: router({
+    list: orgProcedure
+      .input(
+        z.object({
+          date: z.string().optional(),
+          userId: z.string().uuid().optional(),
+        })
+      )
+      .query(async ({ ctx, input }) => {
+        let query = ctx.supabase.from('shifts').select('*');
+
+        if (input.date) {
+          query = query.eq('date', input.date);
+        }
+        if (input.userId) {
+          query = query.eq('user_id', input.userId);
+        }
+
+        const { data: shifts } = await query;
+        return { shifts: shifts ?? [] };
+      }),
+  }),
+
+  /** Callout routes (org-scoped) */
+  callout: router({
+    list: orgProcedure
+      .input(
+        z.object({
+          status: z
+            .enum(['open', 'claimed', 'approved', 'cancelled'])
+            .optional(),
+        })
+      )
+      .query(async ({ ctx, input }) => {
+        let query = ctx.supabase.from('callouts').select('*, shift:shifts(*)');
+
+        if (input.status) {
+          query = query.eq('status', input.status);
+        }
+
+        const { data: callouts } = await query;
+        return { callouts: callouts ?? [] };
+      }),
+  }),
+});
+
+export type AppRouter = typeof appRouter;

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -1,0 +1,161 @@
+/**
+ * tRPC server initialization and middleware definitions.
+ *
+ * This module sets up:
+ * - tRPC context creation (with Supabase client)
+ * - Auth middleware (verifies Supabase session)
+ * - Org context middleware (derives org_id, sets RLS session vars)
+ */
+import { initTRPC, TRPCError } from '@trpc/server';
+import { FetchCreateContextFnOptions } from '@trpc/server/adapters/fetch';
+import { SupabaseClient } from '@supabase/supabase-js';
+import superjson from 'superjson';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { OrgRole } from '@/types/database';
+import { getOrgContext } from '@/lib/orgContext';
+
+/**
+ * Context available to all tRPC procedures.
+ */
+export interface Context {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any>;
+  user: { id: string; email: string } | null;
+}
+
+/**
+ * Extended context after org middleware runs.
+ */
+export interface AuthedOrgContext extends Context {
+  user: { id: string; email: string };
+  orgId: string;
+  orgRole: OrgRole;
+}
+
+/**
+ * Creates the tRPC context for each request.
+ * Initializes a Supabase server client and extracts user from session.
+ */
+export async function createTRPCContext(
+  _opts: FetchCreateContextFnOptions
+): Promise<Context> {
+  const cookieStore = await cookies();
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Missing Supabase environment variables',
+    });
+  }
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options)
+          );
+        } catch {
+          // Called from Server Component — ignored when middleware refreshes sessions
+        }
+      },
+    },
+  });
+
+  // Get authenticated user (if any)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return {
+    supabase,
+    user: user ? { id: user.id, email: user.email! } : null,
+  };
+}
+
+const t = initTRPC.context<Context>().create({
+  transformer: superjson,
+});
+
+export const router = t.router;
+export const publicProcedure = t.procedure;
+export const createCallerFactory = t.createCallerFactory;
+
+/**
+ * Auth middleware — ensures user is authenticated.
+ * Adds typed user to context.
+ */
+const isAuthed = t.middleware(async ({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'You must be logged in to access this resource',
+    });
+  }
+
+  return next({
+    ctx: {
+      ...ctx,
+      user: ctx.user,
+    },
+  });
+});
+
+/**
+ * Org context middleware — derives org_id from user's membership,
+ * sets the PostgreSQL RLS session variable, and adds orgId/orgRole to context.
+ *
+ * Pattern: set_config('app.current_org_id', orgId, true) scoped to the transaction.
+ */
+const withOrgContext = t.middleware(async ({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'You must be logged in to access this resource',
+    });
+  }
+
+  // Derive org context from user's membership
+  const orgCtx = await getOrgContext(ctx.supabase, ctx.user.id);
+
+  // Set PostgreSQL session variable for RLS enforcement
+  const { error } = await ctx.supabase.rpc('set_org_context', {
+    org_id: orgCtx.orgId,
+  });
+
+  if (error) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: `Failed to set org context: ${error.message}`,
+    });
+  }
+
+  return next({
+    ctx: {
+      ...ctx,
+      user: ctx.user,
+      orgId: orgCtx.orgId,
+      orgRole: orgCtx.role,
+    },
+  });
+});
+
+/**
+ * Procedure that requires authentication only (no org context).
+ * Use for auth-related routes like listing user's orgs.
+ */
+export const authedProcedure = t.procedure.use(isAuthed);
+
+/**
+ * Procedure that requires authentication AND org context.
+ * Sets RLS session vars so all subsequent Supabase queries are org-scoped.
+ * Use for all org-scoped operations (shifts, callouts, claims, etc.).
+ */
+export const orgProcedure = t.procedure.use(withOrgContext);

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2,6 +2,28 @@
 // These match our Supabase schema
 
 export type UserRole = 'staff' | 'manager' | 'admin';
+export type OrgRole = 'admin' | 'manager' | 'staff';
+export type OrgPlan = 'free' | 'starter' | 'pro' | 'enterprise';
+export type OrgStatus = 'active' | 'suspended' | 'canceled';
+
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  settings: Record<string, unknown>;
+  plan: OrgPlan;
+  status: OrgStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OrgMember {
+  id: string;
+  org_id: string;
+  user_id: string;
+  role: OrgRole;
+  joined_at: string;
+}
 
 export interface User {
   id: string;
@@ -66,6 +88,16 @@ export interface ClaimWithUser extends Claim {
 export interface Database {
   public: {
     Tables: {
+      organizations: {
+        Row: Organization;
+        Insert: Omit<Organization, 'id' | 'created_at' | 'updated_at'>;
+        Update: Partial<Omit<Organization, 'id'>>;
+      };
+      org_members: {
+        Row: OrgMember;
+        Insert: Omit<OrgMember, 'id' | 'joined_at'>;
+        Update: Partial<Omit<OrgMember, 'id'>>;
+      };
       users: {
         Row: User;
         Insert: Omit<User, 'id' | 'created_at' | 'updated_at'>;

--- a/supabase/migrations/002_org_context.sql
+++ b/supabase/migrations/002_org_context.sql
@@ -1,0 +1,114 @@
+-- Organization context migration
+-- Adds organizations and org_members tables for multi-tenancy
+-- Sets up RLS policies using app.current_org_id session variable
+
+-- Organizations table
+CREATE TABLE public.organizations (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name TEXT NOT NULL,
+  slug TEXT UNIQUE NOT NULL,
+  settings JSONB DEFAULT '{}',
+  plan TEXT NOT NULL DEFAULT 'free' CHECK (plan IN ('free', 'starter', 'pro', 'enterprise')),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended', 'canceled')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Org members table (maps users to organizations with roles)
+CREATE TABLE public.org_members (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  org_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'staff' CHECK (role IN ('admin', 'manager', 'staff')),
+  joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(org_id, user_id)
+);
+
+-- Indexes
+CREATE INDEX idx_org_members_user_id ON public.org_members(user_id);
+CREATE INDEX idx_org_members_org_id ON public.org_members(org_id);
+CREATE INDEX idx_organizations_slug ON public.organizations(slug);
+
+-- Enable RLS
+ALTER TABLE public.organizations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.org_members ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies for organizations
+-- Users can view orgs they belong to
+CREATE POLICY "Members can view their organization"
+  ON public.organizations FOR SELECT
+  USING (
+    id = current_setting('app.current_org_id', true)::uuid
+  );
+
+-- Only admins can update their org
+CREATE POLICY "Admins can update their organization"
+  ON public.organizations FOR UPDATE
+  USING (
+    id = current_setting('app.current_org_id', true)::uuid
+    AND EXISTS (
+      SELECT 1 FROM public.org_members
+      WHERE org_id = id
+        AND user_id = auth.uid()
+        AND role = 'admin'
+    )
+  );
+
+-- RLS policies for org_members
+-- Members can view other members in their org
+CREATE POLICY "Members can view org members"
+  ON public.org_members FOR SELECT
+  USING (
+    org_id = current_setting('app.current_org_id', true)::uuid
+  );
+
+-- Admins can manage org members
+CREATE POLICY "Admins can insert org members"
+  ON public.org_members FOR INSERT
+  WITH CHECK (
+    org_id = current_setting('app.current_org_id', true)::uuid
+    AND EXISTS (
+      SELECT 1 FROM public.org_members
+      WHERE org_id = current_setting('app.current_org_id', true)::uuid
+        AND user_id = auth.uid()
+        AND role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins can update org members"
+  ON public.org_members FOR UPDATE
+  USING (
+    org_id = current_setting('app.current_org_id', true)::uuid
+    AND EXISTS (
+      SELECT 1 FROM public.org_members
+      WHERE org_id = current_setting('app.current_org_id', true)::uuid
+        AND user_id = auth.uid()
+        AND role = 'admin'
+    )
+  );
+
+CREATE POLICY "Admins can delete org members"
+  ON public.org_members FOR DELETE
+  USING (
+    org_id = current_setting('app.current_org_id', true)::uuid
+    AND EXISTS (
+      SELECT 1 FROM public.org_members
+      WHERE org_id = current_setting('app.current_org_id', true)::uuid
+        AND user_id = auth.uid()
+        AND role = 'admin'
+    )
+  );
+
+-- Trigger for updated_at on organizations
+CREATE TRIGGER update_organizations_updated_at
+  BEFORE UPDATE ON public.organizations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Function to set org context session variable for RLS
+-- Called from application layer before running org-scoped queries
+CREATE OR REPLACE FUNCTION public.set_org_context(org_id UUID)
+RETURNS void AS $$
+BEGIN
+  PERFORM set_config('app.current_org_id', org_id::text, true);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary

- **Database migration** (`002_org_context.sql`): Adds `organizations` and `org_members` tables with RLS policies using `app.current_org_id` session variable, plus a `set_org_context()` PostgreSQL function
- **Org context middleware** (`src/lib/orgContext.ts`): `getOrgContext(userId)` queries `org_members` to derive `{ orgId, role }` with 5-minute in-memory caching. Returns 403 FORBIDDEN if user has no org membership
- **tRPC server** (`src/server/trpc.ts`): Three procedure types — `publicProcedure` (no auth), `authedProcedure` (auth only), `orgProcedure` (auth + org context + RLS session vars)
- **Root router** (`src/server/routers/_app.ts`): Health check, user profile, org info, shifts, and callouts routes — all org-scoped routes use `orgProcedure` for automatic RLS isolation
- **API route** (`src/app/api/trpc/[trpc]/route.ts`): Next.js App Router handler for tRPC

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Run migration against Supabase instance
- [ ] Test unauthenticated request to `/api/trpc/health` returns OK
- [ ] Test authenticated user without org membership gets 403 FORBIDDEN
- [ ] Test authenticated user with org membership gets org context set correctly
- [ ] Verify RLS isolation: queries only return data for the user's org

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)