### PR TITLE
feat: add tRPC endpoints for shift CRUD and swap workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,15 @@
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
+        "@tanstack/react-query": "^5.90.20",
+        "@trpc/client": "^11.10.0",
+        "@trpc/next": "^11.10.0",
+        "@trpc/server": "^11.10.0",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "superjson": "^2.2.6",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1607,6 +1613,84 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
+      "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@trpc/client": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.10.0.tgz",
+      "integrity": "sha512-h0s2AwDtuhS8INRb4hlo4z3RKCkarWqlOy+3ffJgrlDxzzW6aLUN+9nDrcN4huPje1Em15tbCOqhIc6oaKYTRw==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@trpc/server": "11.10.0",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/next": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@trpc/next/-/next-11.10.0.tgz",
+      "integrity": "sha512-IhyJKmXCkImGbvrfUi/TtCWYR+cLylJiWXVLqtkJs/byWK7nA0K+zmCUmbnPgr60gv3qp+X2YZpdapD7fyc5Mg==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.59.15",
+        "@trpc/client": "11.10.0",
+        "@trpc/react-query": "11.10.0",
+        "@trpc/server": "11.10.0",
+        "next": "*",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "typescript": ">=5.7.2"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/react-query": {
+          "optional": true
+        },
+        "@trpc/react-query": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trpc/server": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.10.0.tgz",
+      "integrity": "sha512-zZjTrR6He61e5TiT7e/bQqab/jRcXBZM8Fg78Yoo8uh5pz60dzzbYuONNUCOkafv5ppXVMms4NHYfNZgzw50vg==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.7.2"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2729,6 +2813,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/cross-spawn": {
@@ -4487,6 +4586,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -6122,6 +6233,18 @@
         }
       }
     },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6370,7 +6493,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6665,7 +6787,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,15 @@
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
+    "@tanstack/react-query": "^5.90.20",
+    "@trpc/client": "^11.10.0",
+    "@trpc/next": "^11.10.0",
+    "@trpc/server": "^11.10.0",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "superjson": "^2.2.6",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,13 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { appRouter } from '@/server/routers/_app';
+import { createTRPCContext } from '@/server/trpc/context';
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: createTRPCContext,
+  });
+
+export { handler as GET, handler as POST };

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -1,0 +1,10 @@
+import { router } from '../trpc/init';
+import { shiftRouter } from './shift';
+import { swapRouter } from './swap';
+
+export const appRouter = router({
+  shift: shiftRouter,
+  swap: swapRouter,
+});
+
+export type AppRouter = typeof appRouter;

--- a/src/server/routers/shift.ts
+++ b/src/server/routers/shift.ts
@@ -1,0 +1,232 @@
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { router, protectedProcedure, managerProcedure } from '../trpc/init';
+import type { Shift } from '@/types/database';
+
+const TIME_REGEX = /^\d{2}:\d{2}$/;
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+const shiftCreateSchema = z.object({
+  user_id: z.string().uuid(),
+  date: z.string().regex(DATE_REGEX, 'Date must be YYYY-MM-DD'),
+  start_time: z.string().regex(TIME_REGEX, 'Time must be HH:MM'),
+  end_time: z.string().regex(TIME_REGEX, 'Time must be HH:MM'),
+  role: z.string().min(1, 'Role is required'),
+  department: z.string().min(1, 'Department is required'),
+});
+
+const shiftUpdateSchema = z.object({
+  id: z.string().uuid(),
+  user_id: z.string().uuid().optional(),
+  date: z.string().regex(DATE_REGEX, 'Date must be YYYY-MM-DD').optional(),
+  start_time: z.string().regex(TIME_REGEX, 'Time must be HH:MM').optional(),
+  end_time: z.string().regex(TIME_REGEX, 'Time must be HH:MM').optional(),
+  role: z.string().min(1).optional(),
+  department: z.string().min(1).optional(),
+});
+
+/** Check that start_time < end_time */
+function validateTimeRange(start: string, end: string) {
+  if (start >= end) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'start_time must be before end_time',
+    });
+  }
+}
+
+type ShiftTimeslot = Pick<Shift, 'id' | 'start_time' | 'end_time'>;
+
+export const shiftRouter = router({
+  /**
+   * List shifts with optional filters.
+   * Any authenticated user can list shifts.
+   */
+  list: protectedProcedure
+    .input(
+      z
+        .object({
+          department: z.string().optional(),
+          startDate: z.string().regex(DATE_REGEX).optional(),
+          endDate: z.string().regex(DATE_REGEX).optional(),
+          userId: z.string().uuid().optional(),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      let query = ctx.supabase.from('shifts').select('*');
+
+      if (input?.department) {
+        query = query.eq('department', input.department);
+      }
+      if (input?.startDate) {
+        query = query.gte('date', input.startDate);
+      }
+      if (input?.endDate) {
+        query = query.lte('date', input.endDate);
+      }
+      if (input?.userId) {
+        query = query.eq('user_id', input.userId);
+      }
+
+      query = query.order('date', { ascending: true }).order('start_time', { ascending: true });
+
+      const { data, error } = (await query) as { data: Shift[] | null; error: { message: string } | null };
+
+      if (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: error.message,
+        });
+      }
+
+      return data ?? [];
+    }),
+
+  /**
+   * Create a new shift. Manager/admin only.
+   * Validates no overlapping shifts for the same user on the same date.
+   */
+  create: managerProcedure.input(shiftCreateSchema).mutation(async ({ ctx, input }) => {
+    validateTimeRange(input.start_time, input.end_time);
+
+    // Check for overlapping shifts for this user on this date
+    const { data: existing, error: checkError } = (await ctx.supabase
+      .from('shifts')
+      .select('id, start_time, end_time')
+      .eq('user_id', input.user_id)
+      .eq('date', input.date)) as { data: ShiftTimeslot[] | null; error: { message: string } | null };
+
+    if (checkError) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: checkError.message,
+      });
+    }
+
+    const hasOverlap = (existing ?? []).some(
+      (shift) => input.start_time < shift.end_time && input.end_time > shift.start_time
+    );
+
+    if (hasOverlap) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'This shift overlaps with an existing shift for the same user',
+      });
+    }
+
+    const { data, error } = (await ctx.supabase
+      .from('shifts')
+      .insert({
+        user_id: input.user_id,
+        date: input.date,
+        start_time: input.start_time,
+        end_time: input.end_time,
+        role: input.role,
+        department: input.department,
+      } as never)
+      .select()
+      .single()) as { data: Shift | null; error: { message: string } | null };
+
+    if (error || !data) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: error?.message ?? 'Failed to create shift',
+      });
+    }
+
+    return data;
+  }),
+
+  /**
+   * Update an existing shift. Manager/admin only.
+   * Re-validates overlap if date or times change.
+   */
+  update: managerProcedure.input(shiftUpdateSchema).mutation(async ({ ctx, input }) => {
+    const { id, ...updates } = input;
+
+    // Fetch the existing shift
+    const { data: existing, error: fetchError } = (await ctx.supabase
+      .from('shifts')
+      .select('*')
+      .eq('id', id)
+      .single()) as { data: Shift | null; error: { message: string } | null };
+
+    if (fetchError || !existing) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Shift not found',
+      });
+    }
+
+    const finalDate = updates.date ?? existing.date;
+    const finalStart = updates.start_time ?? existing.start_time;
+    const finalEnd = updates.end_time ?? existing.end_time;
+    const finalUserId = updates.user_id ?? existing.user_id;
+
+    validateTimeRange(finalStart, finalEnd);
+
+    // Check for overlapping shifts (excluding this one)
+    const { data: others, error: checkError } = (await ctx.supabase
+      .from('shifts')
+      .select('id, start_time, end_time')
+      .eq('user_id', finalUserId)
+      .eq('date', finalDate)
+      .neq('id', id)) as { data: ShiftTimeslot[] | null; error: { message: string } | null };
+
+    if (checkError) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: checkError.message,
+      });
+    }
+
+    const hasOverlap = (others ?? []).some(
+      (shift) => finalStart < shift.end_time && finalEnd > shift.start_time
+    );
+
+    if (hasOverlap) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Updated shift would overlap with an existing shift for the same user',
+      });
+    }
+
+    const { data, error } = (await ctx.supabase
+      .from('shifts')
+      .update(updates as never)
+      .eq('id', id)
+      .select()
+      .single()) as { data: Shift | null; error: { message: string } | null };
+
+    if (error || !data) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: error?.message ?? 'Failed to update shift',
+      });
+    }
+
+    return data;
+  }),
+
+  /**
+   * Delete a shift. Manager/admin only.
+   */
+  delete: managerProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = (await ctx.supabase
+        .from('shifts')
+        .delete()
+        .eq('id', input.id)) as { error: { message: string } | null };
+
+      if (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: error.message,
+        });
+      }
+
+      return { success: true };
+    }),
+});

--- a/src/server/routers/swap.ts
+++ b/src/server/routers/swap.ts
@@ -1,0 +1,352 @@
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { router, protectedProcedure, managerProcedure } from '../trpc/init';
+import type { Shift, SwapRequest } from '@/types/database';
+
+type ShiftTimeslot = Pick<Shift, 'id' | 'start_time' | 'end_time'>;
+
+export const swapRouter = router({
+  /**
+   * List swap requests visible to the current user.
+   * Staff see: requests they created + requests targeting their shifts.
+   * Managers/admins see all swap requests.
+   */
+  list: protectedProcedure
+    .input(
+      z
+        .object({
+          status: z
+            .enum(['pending', 'approved', 'denied', 'cancelled'])
+            .optional(),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      const isManager =
+        ctx.profile.role === 'manager' || ctx.profile.role === 'admin';
+
+      let query = ctx.supabase.from('swap_requests').select('*');
+
+      if (input?.status) {
+        query = query.eq('status', input.status);
+      }
+
+      if (!isManager) {
+        // Staff see their own requests + requests for shifts they own
+        const { data: userShiftIds } = (await ctx.supabase
+          .from('shifts')
+          .select('id')
+          .eq('user_id', ctx.user.id)) as { data: { id: string }[] | null };
+
+        const shiftIds = (userShiftIds ?? []).map((s) => s.id);
+
+        query = query.or(
+          `requester_id.eq.${ctx.user.id}${shiftIds.length > 0 ? `,shift_id.in.(${shiftIds.join(',')})` : ''}`
+        );
+      }
+
+      query = query.order('created_at', { ascending: false });
+
+      const { data, error } = (await query) as {
+        data: SwapRequest[] | null;
+        error: { message: string } | null;
+      };
+
+      if (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: error.message,
+        });
+      }
+
+      return data ?? [];
+    }),
+
+  /**
+   * Create a swap request.
+   * Staff member requests to swap/give up one of their shifts.
+   */
+  create: protectedProcedure
+    .input(
+      z.object({
+        shiftId: z.string().uuid(),
+        notes: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Verify the shift belongs to the requesting user
+      const { data: shift, error: shiftError } = (await ctx.supabase
+        .from('shifts')
+        .select('*')
+        .eq('id', input.shiftId)
+        .single()) as { data: Shift | null; error: { message: string } | null };
+
+      if (shiftError || !shift) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Shift not found',
+        });
+      }
+
+      if (shift.user_id !== ctx.user.id) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You can only create swap requests for your own shifts',
+        });
+      }
+
+      // Check no pending swap request already exists for this shift
+      const { data: existingRequests } = (await ctx.supabase
+        .from('swap_requests')
+        .select('id')
+        .eq('shift_id', input.shiftId)
+        .eq('status', 'pending')) as { data: { id: string }[] | null };
+
+      if (existingRequests && existingRequests.length > 0) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'A pending swap request already exists for this shift',
+        });
+      }
+
+      const { data, error } = (await ctx.supabase
+        .from('swap_requests')
+        .insert({
+          shift_id: input.shiftId,
+          requester_id: ctx.user.id,
+          notes: input.notes ?? null,
+          status: 'pending',
+        } as never)
+        .select()
+        .single()) as { data: SwapRequest | null; error: { message: string } | null };
+
+      if (error || !data) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: error?.message ?? 'Failed to create swap request',
+        });
+      }
+
+      return data;
+    }),
+
+  /**
+   * Approve a swap request. Manager/admin only.
+   * Assigns the replacement user to the shift.
+   */
+  approve: managerProcedure
+    .input(
+      z.object({
+        requestId: z.string().uuid(),
+        replacementUserId: z.string().uuid(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Fetch the swap request
+      const { data: request, error: reqError } = (await ctx.supabase
+        .from('swap_requests')
+        .select('*')
+        .eq('id', input.requestId)
+        .single()) as { data: SwapRequest | null; error: { message: string } | null };
+
+      if (reqError || !request) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Swap request not found',
+        });
+      }
+
+      if (request.status !== 'pending') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Cannot approve a request with status "${request.status}"`,
+        });
+      }
+
+      // Verify the replacement user exists
+      const { data: replacementUser, error: userError } = (await ctx.supabase
+        .from('users')
+        .select('id')
+        .eq('id', input.replacementUserId)
+        .single()) as { data: { id: string } | null; error: { message: string } | null };
+
+      if (userError || !replacementUser) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Replacement user not found',
+        });
+      }
+
+      // Fetch the shift to check for overlaps with the replacement user
+      const { data: shift } = (await ctx.supabase
+        .from('shifts')
+        .select('*')
+        .eq('id', request.shift_id)
+        .single()) as { data: Shift | null };
+
+      if (!shift) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Associated shift not found',
+        });
+      }
+
+      // Check that replacement user doesn't have an overlapping shift
+      const { data: existingShifts } = (await ctx.supabase
+        .from('shifts')
+        .select('id, start_time, end_time')
+        .eq('user_id', input.replacementUserId)
+        .eq('date', shift.date)
+        .neq('id', shift.id)) as { data: ShiftTimeslot[] | null };
+
+      const hasOverlap = (existingShifts ?? []).some(
+        (s) => shift.start_time < s.end_time && shift.end_time > s.start_time
+      );
+
+      if (hasOverlap) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message:
+            'Replacement user already has an overlapping shift on this date',
+        });
+      }
+
+      // Update the swap request status
+      const { data: updatedRequest, error: updateReqError } = (await ctx.supabase
+        .from('swap_requests')
+        .update({
+          status: 'approved',
+          replacement_user_id: input.replacementUserId,
+        } as never)
+        .eq('id', input.requestId)
+        .select()
+        .single()) as { data: SwapRequest | null; error: { message: string } | null };
+
+      if (updateReqError || !updatedRequest) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: updateReqError?.message ?? 'Failed to approve request',
+        });
+      }
+
+      // Update the shift to assign to replacement user
+      const { error: shiftUpdateError } = (await ctx.supabase
+        .from('shifts')
+        .update({ user_id: input.replacementUserId } as never)
+        .eq('id', request.shift_id)) as { error: { message: string } | null };
+
+      if (shiftUpdateError) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: shiftUpdateError.message,
+        });
+      }
+
+      return updatedRequest;
+    }),
+
+  /**
+   * Deny a swap request. Manager/admin only.
+   */
+  deny: managerProcedure
+    .input(
+      z.object({
+        requestId: z.string().uuid(),
+        reason: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { data: request, error: reqError } = (await ctx.supabase
+        .from('swap_requests')
+        .select('*')
+        .eq('id', input.requestId)
+        .single()) as { data: SwapRequest | null; error: { message: string } | null };
+
+      if (reqError || !request) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Swap request not found',
+        });
+      }
+
+      if (request.status !== 'pending') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Cannot deny a request with status "${request.status}"`,
+        });
+      }
+
+      const { data, error } = (await ctx.supabase
+        .from('swap_requests')
+        .update({
+          status: 'denied',
+          reason: input.reason ?? null,
+        } as never)
+        .eq('id', input.requestId)
+        .select()
+        .single()) as { data: SwapRequest | null; error: { message: string } | null };
+
+      if (error || !data) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: error?.message ?? 'Failed to deny request',
+        });
+      }
+
+      return data;
+    }),
+
+  /**
+   * Cancel a swap request. Only the requester can cancel, and only if pending.
+   */
+  cancel: protectedProcedure
+    .input(
+      z.object({
+        requestId: z.string().uuid(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { data: request, error: reqError } = (await ctx.supabase
+        .from('swap_requests')
+        .select('*')
+        .eq('id', input.requestId)
+        .single()) as { data: SwapRequest | null; error: { message: string } | null };
+
+      if (reqError || !request) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Swap request not found',
+        });
+      }
+
+      if (request.requester_id !== ctx.user.id) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only the requester can cancel a swap request',
+        });
+      }
+
+      if (request.status !== 'pending') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Cannot cancel a request with status "${request.status}"`,
+        });
+      }
+
+      const { data, error } = (await ctx.supabase
+        .from('swap_requests')
+        .update({ status: 'cancelled' } as never)
+        .eq('id', input.requestId)
+        .select()
+        .single()) as { data: SwapRequest | null; error: { message: string } | null };
+
+      if (error || !data) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: error?.message ?? 'Failed to cancel request',
+        });
+      }
+
+      return data;
+    }),
+});

--- a/src/server/trpc/context.ts
+++ b/src/server/trpc/context.ts
@@ -1,0 +1,49 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import type { Database, User } from '@/types/database';
+
+export async function createTRPCContext() {
+  const cookieStore = await cookies();
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Missing Supabase environment variables');
+  }
+
+  const supabase = createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options)
+          );
+        } catch {
+          // Called from Server Component - middleware handles session refresh
+        }
+      },
+    },
+  });
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let profile: User | null = null;
+  if (user) {
+    const { data } = await supabase
+      .from('users')
+      .select('*')
+      .eq('id', user.id)
+      .single() as { data: User | null };
+    profile = data;
+  }
+
+  return { supabase, user, profile };
+}
+
+export type Context = Awaited<ReturnType<typeof createTRPCContext>>;

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -1,0 +1,50 @@
+import { initTRPC, TRPCError } from '@trpc/server';
+import superjson from 'superjson';
+import type { Context } from './context';
+
+const t = initTRPC.context<Context>().create({
+  transformer: superjson,
+});
+
+export const router = t.router;
+export const publicProcedure = t.procedure;
+
+/** Requires an authenticated user */
+export const protectedProcedure = t.procedure.use(async ({ ctx, next }) => {
+  if (!ctx.user || !ctx.profile) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'You must be logged in',
+    });
+  }
+  return next({
+    ctx: {
+      ...ctx,
+      user: ctx.user,
+      profile: ctx.profile,
+    },
+  });
+});
+
+/** Requires manager or admin role */
+export const managerProcedure = t.procedure.use(async ({ ctx, next }) => {
+  if (!ctx.user || !ctx.profile) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'You must be logged in',
+    });
+  }
+  if (ctx.profile.role !== 'manager' && ctx.profile.role !== 'admin') {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Manager or admin role required',
+    });
+  }
+  return next({
+    ctx: {
+      ...ctx,
+      user: ctx.user,
+      profile: ctx.profile,
+    },
+  });
+});

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -51,6 +51,20 @@ export interface Claim {
   created_at: string;
 }
 
+export type SwapRequestStatus = 'pending' | 'approved' | 'denied' | 'cancelled';
+
+export interface SwapRequest {
+  id: string;
+  shift_id: string;
+  requester_id: string;
+  replacement_user_id: string | null;
+  notes: string | null;
+  reason: string | null;
+  status: SwapRequestStatus;
+  created_at: string;
+  updated_at: string;
+}
+
 // Joined types for display
 export interface CallOutWithDetails extends CallOut {
   shift: Shift;
@@ -62,30 +76,134 @@ export interface ClaimWithUser extends Claim {
   user: User;
 }
 
-// Database schema type for Supabase
+// Database schema type for Supabase client
 export interface Database {
   public: {
     Tables: {
       users: {
         Row: User;
-        Insert: Omit<User, 'id' | 'created_at' | 'updated_at'>;
-        Update: Partial<Omit<User, 'id'>>;
+        Insert: {
+          id: string;
+          email: string;
+          name: string;
+          phone?: string | null;
+          role?: string;
+          department?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          email?: string;
+          name?: string;
+          phone?: string | null;
+          role?: string;
+          department?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
       };
       shifts: {
         Row: Shift;
-        Insert: Omit<Shift, 'id' | 'created_at'>;
-        Update: Partial<Omit<Shift, 'id'>>;
+        Insert: {
+          id?: string;
+          user_id: string;
+          date: string;
+          start_time: string;
+          end_time: string;
+          role: string;
+          department: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          date?: string;
+          start_time?: string;
+          end_time?: string;
+          role?: string;
+          department?: string;
+          created_at?: string;
+        };
+        Relationships: [];
       };
       callouts: {
         Row: CallOut;
-        Insert: Omit<CallOut, 'id' | 'created_at' | 'updated_at' | 'posted_at'>;
-        Update: Partial<Omit<CallOut, 'id'>>;
+        Insert: {
+          id?: string;
+          shift_id: string;
+          user_id: string;
+          reason?: string | null;
+          posted_at?: string;
+          status?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          shift_id?: string;
+          user_id?: string;
+          reason?: string | null;
+          posted_at?: string;
+          status?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
       };
       claims: {
         Row: Claim;
-        Insert: Omit<Claim, 'id' | 'created_at' | 'claimed_at'>;
-        Update: Partial<Omit<Claim, 'id'>>;
+        Insert: {
+          id?: string;
+          callout_id: string;
+          user_id: string;
+          claimed_at?: string;
+          status?: string;
+          approved_by?: string | null;
+          approved_at?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          callout_id?: string;
+          user_id?: string;
+          claimed_at?: string;
+          status?: string;
+          approved_by?: string | null;
+          approved_at?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
+      swap_requests: {
+        Row: SwapRequest;
+        Insert: {
+          id?: string;
+          shift_id: string;
+          requester_id: string;
+          replacement_user_id?: string | null;
+          notes?: string | null;
+          reason?: string | null;
+          status?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          shift_id?: string;
+          requester_id?: string;
+          replacement_user_id?: string | null;
+          notes?: string | null;
+          reason?: string | null;
+          status?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
       };
     };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
   };
 }

--- a/supabase/migrations/002_swap_requests.sql
+++ b/supabase/migrations/002_swap_requests.sql
@@ -1,0 +1,61 @@
+-- Swap Requests table for shift swap workflow
+CREATE TABLE public.swap_requests (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  shift_id UUID NOT NULL REFERENCES public.shifts(id) ON DELETE CASCADE,
+  requester_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  replacement_user_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  notes TEXT,
+  reason TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'denied', 'cancelled')),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX idx_swap_requests_shift_id ON public.swap_requests(shift_id);
+CREATE INDEX idx_swap_requests_requester_id ON public.swap_requests(requester_id);
+CREATE INDEX idx_swap_requests_status ON public.swap_requests(status);
+
+-- RLS
+ALTER TABLE public.swap_requests ENABLE ROW LEVEL SECURITY;
+
+-- Everyone can view swap requests
+CREATE POLICY "Anyone can view swap requests" ON public.swap_requests
+  FOR SELECT USING (true);
+
+-- Staff can create swap requests for their own shifts
+CREATE POLICY "Users can create swap requests for own shifts" ON public.swap_requests
+  FOR INSERT WITH CHECK (
+    auth.uid() = requester_id AND
+    EXISTS (SELECT 1 FROM public.shifts WHERE id = shift_id AND user_id = auth.uid())
+  );
+
+-- Requester can update own pending requests (cancel), managers can update any
+CREATE POLICY "Users can update own or managers can update any" ON public.swap_requests
+  FOR UPDATE USING (
+    auth.uid() = requester_id OR
+    EXISTS (SELECT 1 FROM public.users WHERE id = auth.uid() AND role IN ('manager', 'admin'))
+  );
+
+-- Trigger for updated_at
+CREATE TRIGGER update_swap_requests_updated_at
+  BEFORE UPDATE ON public.swap_requests
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Also update shifts RLS to allow managers to update any shift (for swap approvals)
+CREATE POLICY "Managers can update any shift" ON public.shifts
+  FOR UPDATE USING (
+    EXISTS (SELECT 1 FROM public.users WHERE id = auth.uid() AND role IN ('manager', 'admin'))
+  );
+
+-- Allow managers to insert shifts
+CREATE POLICY "Managers can insert shifts" ON public.shifts
+  FOR INSERT WITH CHECK (
+    EXISTS (SELECT 1 FROM public.users WHERE id = auth.uid() AND role IN ('manager', 'admin'))
+  );
+
+-- Allow managers to delete shifts
+CREATE POLICY "Managers can delete shifts" ON public.shifts
+  FOR DELETE USING (
+    EXISTS (SELECT 1 FROM public.users WHERE id = auth.uid() AND role IN ('manager', 'admin'))
+  );


### PR DESCRIPTION
Closes #16

## Summary

- **tRPC infrastructure**: Set up tRPC v11 with Next.js App Router, including Supabase auth context, protected/manager-only procedure middleware, and superjson transformer
- **Shift CRUD endpoints** (`shift.list`, `shift.create`, `shift.update`, `shift.delete`): Manager/admin gated mutations with server-side overlap validation per user per date
- **Swap workflow endpoints** (`swap.list`, `swap.create`, `swap.approve`, `swap.deny`, `swap.cancel`): Full status lifecycle (pending → approved/denied/cancelled) with ownership checks, duplicate prevention, and overlap validation on approval
- **Database migration**: New `swap_requests` table with RLS policies, plus manager-level RLS policies for shift mutations

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Run `002_swap_requests.sql` migration against Supabase
- [ ] Test shift CRUD via `/api/trpc/shift.list`, `/api/trpc/shift.create`, etc.
- [ ] Test swap workflow: create → approve (with replacement user) → verify shift.user_id updated
- [ ] Test swap deny and cancel flows
- [ ] Verify overlap validation rejects conflicting shifts
- [ ] Verify auth guards: unauthenticated → 401, staff on manager routes → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)