### PR TITLE
feat: in-app notification system with bell icon and email stub

### DIFF
--- a/src/app/dashboard/NotificationBell.tsx
+++ b/src/app/dashboard/NotificationBell.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { TRPCProvider } from '@/components/TRPCProvider';
+import { NotificationDropdown } from '@/components/NotificationDropdown';
+
+export function NotificationBell() {
+  return (
+    <TRPCProvider>
+      <NotificationDropdown />
+    </TRPCProvider>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { requireAuth } from '@/lib/auth';
 import { createClient } from '@/lib/supabase/server';
 import Link from 'next/link';
 import { Shift } from '@/types/database';
+import { NotificationBell } from './NotificationBell';
 
 export const dynamic = 'force-dynamic';
 
@@ -32,6 +33,7 @@ export default async function DashboardPage() {
         <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
           <h1 className="text-2xl font-bold text-gray-900">ShiftSwap</h1>
           <div className="flex items-center gap-4">
+            <NotificationBell />
             <span className="text-gray-600">
               {session.name || session.email}
               <span className="ml-2 px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded">

--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { trpc } from '@/lib/trpc';
+
+export function NotificationDropdown() {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  const { data, refetch } = trpc.notification.list.useQuery(undefined, {
+    refetchInterval: 30_000, // Poll every 30s for new notifications
+  });
+
+  const markRead = trpc.notification.markRead.useMutation({
+    onSuccess: () => refetch(),
+  });
+
+  const markAllRead = trpc.notification.markAllRead.useMutation({
+    onSuccess: () => refetch(),
+  });
+
+  const notifications = data?.notifications ?? [];
+  const unreadCount = data?.unreadCount ?? 0;
+  const displayNotifications = notifications.slice(0, 10);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  function handleNotificationClick(notificationId: string, link: string | null) {
+    markRead.mutate({ id: notificationId });
+    setIsOpen(false);
+    if (link) {
+      router.push(link);
+    }
+  }
+
+  function handleMarkAllRead() {
+    markAllRead.mutate();
+  }
+
+  function formatTime(dateString: string): string {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60_000);
+    const diffHours = Math.floor(diffMs / 3_600_000);
+    const diffDays = Math.floor(diffMs / 86_400_000);
+
+    if (diffMins < 1) return 'Just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return date.toLocaleDateString();
+  }
+
+  function getTypeIcon(type: string): string {
+    switch (type) {
+      case 'swap_request':
+        return '🔄';
+      case 'swap_approved':
+        return '✅';
+      case 'swap_denied':
+        return '❌';
+      case 'shift_claimed':
+        return '✋';
+      default:
+        return '📢';
+    }
+  }
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      {/* Bell icon button */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="relative p-2 text-gray-600 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-lg"
+        aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
+      >
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+          />
+        </svg>
+
+        {/* Unread count badge */}
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-bold leading-none text-white bg-red-500 rounded-full min-w-[18px]">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Dropdown panel */}
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-80 bg-white rounded-lg shadow-lg border border-gray-200 z-50">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+            <h3 className="text-sm font-semibold text-gray-900">
+              Notifications
+            </h3>
+            {unreadCount > 0 && (
+              <button
+                onClick={handleMarkAllRead}
+                className="text-xs text-blue-600 hover:text-blue-800"
+                disabled={markAllRead.isPending}
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          {/* Notification list */}
+          <div className="max-h-96 overflow-y-auto">
+            {displayNotifications.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-gray-500">
+                No notifications yet
+              </div>
+            ) : (
+              displayNotifications.map((notification) => (
+                <button
+                  key={notification.id}
+                  onClick={() =>
+                    handleNotificationClick(notification.id, notification.link)
+                  }
+                  className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-50 last:border-b-0 transition-colors ${
+                    !notification.read_at ? 'bg-blue-50/50' : ''
+                  }`}
+                >
+                  <div className="flex gap-3">
+                    <span className="text-lg flex-shrink-0 mt-0.5">
+                      {getTypeIcon(notification.type)}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-start justify-between gap-2">
+                        <p
+                          className={`text-sm truncate ${
+                            !notification.read_at
+                              ? 'font-semibold text-gray-900'
+                              : 'text-gray-700'
+                          }`}
+                        >
+                          {notification.title}
+                        </p>
+                        {!notification.read_at && (
+                          <span className="flex-shrink-0 w-2 h-2 mt-1.5 bg-blue-500 rounded-full" />
+                        )}
+                      </div>
+                      <p className="text-xs text-gray-500 truncate mt-0.5">
+                        {notification.message}
+                      </p>
+                      <p className="text-xs text-gray-400 mt-1">
+                        {formatTime(notification.created_at)}
+                      </p>
+                    </div>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TRPCProvider.tsx
+++ b/src/components/TRPCProvider.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { httpBatchLink } from '@trpc/client';
+import superjson from 'superjson';
+import { trpc } from '@/lib/trpc';
+
+function getBaseUrl() {
+  if (typeof window !== 'undefined') return '';
+  // SSR — use localhost
+  return `http://localhost:${process.env.PORT ?? 3000}`;
+}
+
+export function TRPCProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
+
+  const [trpcClient] = useState(() =>
+    trpc.createClient({
+      links: [
+        httpBatchLink({
+          url: `${getBaseUrl()}/api/trpc`,
+          transformer: superjson,
+        }),
+      ],
+    }),
+  );
+
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </trpc.Provider>
+  );
+}

--- a/src/lib/__tests__/notifications.test.ts
+++ b/src/lib/__tests__/notifications.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock Supabase client
+// ---------------------------------------------------------------------------
+
+function createMockSupabase() {
+  const insertFn = vi.fn().mockResolvedValue({ error: null });
+  const fromFn = vi.fn().mockReturnValue({ insert: insertFn });
+
+  return {
+    client: { from: fromFn } as unknown,
+    fromFn,
+    insertFn,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Reset module-level ENABLE_EMAIL env before each import
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.ENABLE_EMAIL;
+  vi.resetModules();
+});
+
+describe('createNotification', () => {
+  it('inserts a notification row into the database', async () => {
+    const { createNotification } = await import('../notifications');
+    const { client, insertFn } = createMockSupabase();
+
+    await createNotification(client as never, {
+      orgId: 'org-1',
+      userId: 'user-1',
+      type: 'swap_request',
+      title: 'New Swap Request',
+      message: 'Alice posted a call-out for Jan 15',
+      link: '/callouts/abc',
+    });
+
+    expect(insertFn).toHaveBeenCalledWith({
+      org_id: 'org-1',
+      user_id: 'user-1',
+      type: 'swap_request',
+      title: 'New Swap Request',
+      message: 'Alice posted a call-out for Jan 15',
+      link: '/callouts/abc',
+      read_at: null,
+    });
+  });
+
+  it('handles missing link gracefully', async () => {
+    const { createNotification } = await import('../notifications');
+    const { client, insertFn } = createMockSupabase();
+
+    await createNotification(client as never, {
+      orgId: 'org-1',
+      userId: 'user-1',
+      type: 'general',
+      title: 'Hello',
+      message: 'General notification',
+    });
+
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({ link: null }),
+    );
+  });
+
+  it('logs error but does not throw on insert failure', async () => {
+    const { createNotification } = await import('../notifications');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const insertFn = vi.fn().mockResolvedValue({ error: { message: 'insert failed' } });
+    const client = { from: vi.fn().mockReturnValue({ insert: insertFn }) };
+
+    await createNotification(client as never, {
+      orgId: 'org-1',
+      userId: 'user-1',
+      type: 'swap_approved',
+      title: 'Approved',
+      message: 'Swap approved',
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[notifications] Failed to create notification:',
+      'insert failed',
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('notifySwapRequested', () => {
+  it('creates notifications for all managers', async () => {
+    const { notifySwapRequested } = await import('../notifications');
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const client = { from: vi.fn().mockReturnValue({ insert: insertFn }) };
+
+    await notifySwapRequested(client as never, {
+      orgId: 'org-1',
+      managerUserIds: ['mgr-1', 'mgr-2'],
+      requesterName: 'Alice',
+      shiftDate: '2025-01-15',
+      calloutId: 'callout-abc',
+    });
+
+    expect(insertFn).toHaveBeenCalledTimes(2);
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'mgr-1',
+        type: 'swap_request',
+        title: 'New Swap Request',
+      }),
+    );
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'mgr-2',
+        type: 'swap_request',
+      }),
+    );
+  });
+});
+
+describe('notifySwapApproved', () => {
+  it('creates a notification for the requester', async () => {
+    const { notifySwapApproved } = await import('../notifications');
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const client = { from: vi.fn().mockReturnValue({ insert: insertFn }) };
+
+    await notifySwapApproved(client as never, {
+      orgId: 'org-1',
+      requesterUserId: 'user-1',
+      shiftDate: '2025-01-15',
+      calloutId: 'callout-abc',
+    });
+
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        type: 'swap_approved',
+        title: 'Swap Approved',
+        link: '/callouts/callout-abc',
+      }),
+    );
+  });
+});
+
+describe('notifySwapDenied', () => {
+  it('creates a notification for the requester', async () => {
+    const { notifySwapDenied } = await import('../notifications');
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const client = { from: vi.fn().mockReturnValue({ insert: insertFn }) };
+
+    await notifySwapDenied(client as never, {
+      orgId: 'org-1',
+      requesterUserId: 'user-1',
+      shiftDate: '2025-01-15',
+      calloutId: 'callout-abc',
+    });
+
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        type: 'swap_denied',
+        title: 'Swap Denied',
+      }),
+    );
+  });
+});
+
+describe('sendEmail', () => {
+  it('logs the email stub when called', async () => {
+    const { sendEmail } = await import('../notifications');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await sendEmail({
+      to: 'user@test.com',
+      template: 'swap_request',
+      data: { title: 'Test', message: 'Test message' },
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[email-stub] Would send email:',
+      expect.objectContaining({
+        to: 'user@test.com',
+        template: 'swap_request',
+      }),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('does not send email when ENABLE_EMAIL is not set', async () => {
+    const { createNotification } = await import('../notifications');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { client } = createMockSupabase();
+
+    await createNotification(client as never, {
+      orgId: 'org-1',
+      userId: 'user-1',
+      type: 'swap_request',
+      title: 'Test',
+      message: 'No email',
+    });
+
+    // sendEmail should NOT have been called (no email-stub log)
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      '[email-stub] Would send email:',
+      expect.anything(),
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,188 @@
+/**
+ * Notification service — creates in-app notifications and stubs email sending.
+ *
+ * Notification triggers fire when swap events occur (request created,
+ * approved, denied). Email sending is feature-flagged OFF by default.
+ */
+import { SupabaseClient } from '@supabase/supabase-js';
+import { NotificationType } from '@/types/database';
+
+// ---------------------------------------------------------------------------
+// Feature flag for email sending
+// ---------------------------------------------------------------------------
+
+const ENABLE_EMAIL = process.env.ENABLE_EMAIL === 'true';
+
+// ---------------------------------------------------------------------------
+// Core: create a notification row
+// ---------------------------------------------------------------------------
+
+interface CreateNotificationParams {
+  orgId: string;
+  userId: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  link?: string;
+}
+
+/**
+ * Insert a notification into the database for a specific user.
+ * Also triggers a stubbed email if the feature flag is enabled.
+ */
+export async function createNotification(
+  supabase: SupabaseClient,
+  params: CreateNotificationParams,
+): Promise<void> {
+  const { orgId, userId, type, title, message, link } = params;
+
+  const { error } = await supabase.from('notifications').insert({
+    org_id: orgId,
+    user_id: userId,
+    type,
+    title,
+    message,
+    link: link ?? null,
+    read_at: null,
+  });
+
+  if (error) {
+    console.error('[notifications] Failed to create notification:', error.message);
+  }
+
+  // Attempt email (stubbed, feature-flagged OFF by default)
+  if (ENABLE_EMAIL) {
+    const templateMap: Record<NotificationType, string> = {
+      swap_request: 'swap_request',
+      swap_approved: 'swap_approved',
+      swap_denied: 'swap_denied',
+      shift_claimed: 'shift_claimed',
+      general: 'general',
+    };
+
+    await sendEmail({
+      to: userId, // In a real implementation, resolve to email address
+      template: templateMap[type],
+      data: { title, message, link },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Swap event triggers
+// ---------------------------------------------------------------------------
+
+/**
+ * Notify managers when a swap request (callout) is created.
+ */
+export async function notifySwapRequested(
+  supabase: SupabaseClient,
+  params: {
+    orgId: string;
+    managerUserIds: string[];
+    requesterName: string;
+    shiftDate: string;
+    calloutId: string;
+  },
+): Promise<void> {
+  const { orgId, managerUserIds, requesterName, shiftDate, calloutId } = params;
+
+  await Promise.all(
+    managerUserIds.map((managerId) =>
+      createNotification(supabase, {
+        orgId,
+        userId: managerId,
+        type: 'swap_request',
+        title: 'New Swap Request',
+        message: `${requesterName} posted a call-out for ${shiftDate}`,
+        link: `/callouts/${calloutId}`,
+      }),
+    ),
+  );
+}
+
+/**
+ * Notify the requester when their swap is approved.
+ */
+export async function notifySwapApproved(
+  supabase: SupabaseClient,
+  params: {
+    orgId: string;
+    requesterUserId: string;
+    shiftDate: string;
+    calloutId: string;
+  },
+): Promise<void> {
+  const { orgId, requesterUserId, shiftDate, calloutId } = params;
+
+  await createNotification(supabase, {
+    orgId,
+    userId: requesterUserId,
+    type: 'swap_approved',
+    title: 'Swap Approved',
+    message: `Your call-out for ${shiftDate} has been approved`,
+    link: `/callouts/${calloutId}`,
+  });
+}
+
+/**
+ * Notify the requester when their swap is denied.
+ */
+export async function notifySwapDenied(
+  supabase: SupabaseClient,
+  params: {
+    orgId: string;
+    requesterUserId: string;
+    shiftDate: string;
+    calloutId: string;
+  },
+): Promise<void> {
+  const { orgId, requesterUserId, shiftDate, calloutId } = params;
+
+  await createNotification(supabase, {
+    orgId,
+    userId: requesterUserId,
+    type: 'swap_denied',
+    title: 'Swap Denied',
+    message: `Your call-out for ${shiftDate} has been denied`,
+    link: `/callouts/${calloutId}`,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Email stub (feature-flagged OFF)
+// ---------------------------------------------------------------------------
+
+interface SendEmailParams {
+  to: string;
+  template: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Stubbed email sending function.
+ *
+ * Currently logs to console. When ENABLE_EMAIL=true, this will be called
+ * but still only logs — the actual email provider (e.g. Resend) needs to
+ * be integrated.
+ *
+ * TODO: Integrate Resend or Supabase edge function for actual email delivery.
+ * Email templates needed: swap_request.html, swap_approved.html, swap_denied.html
+ */
+export async function sendEmail(params: SendEmailParams): Promise<void> {
+  console.log('[email-stub] Would send email:', {
+    to: params.to,
+    template: params.template,
+    data: params.data,
+  });
+
+  // TODO: Replace with actual email provider integration
+  // Example with Resend:
+  // const resend = new Resend(process.env.RESEND_API_KEY);
+  // await resend.emails.send({
+  //   from: 'ShiftSwap <notifications@shiftswap.app>',
+  //   to: params.to,
+  //   subject: params.data.title,
+  //   html: renderTemplate(params.template, params.data),
+  // });
+}

--- a/src/lib/trpc.ts
+++ b/src/lib/trpc.ts
@@ -1,0 +1,13 @@
+/**
+ * tRPC React client hooks.
+ *
+ * Import `trpc` from this module in client components to call tRPC endpoints:
+ *
+ * ```tsx
+ * const { data } = trpc.notification.list.useQuery();
+ * ```
+ */
+import { createTRPCReact } from '@trpc/react-query';
+import type { AppRouter } from '@/server/routers/_app';
+
+export const trpc = createTRPCReact<AppRouter>();

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -7,6 +7,7 @@
  */
 import { z } from 'zod';
 import { router, publicProcedure, authedProcedure, orgProcedure } from '../trpc';
+import { notificationRouter } from './notification';
 
 export const appRouter = router({
   /** Health check — public, no auth required */
@@ -72,6 +73,9 @@ export const appRouter = router({
         return { shifts: shifts ?? [] };
       }),
   }),
+
+  /** Notification routes (org-scoped) */
+  notification: notificationRouter,
 
   /** Callout routes (org-scoped) */
   callout: router({

--- a/src/server/routers/notification.ts
+++ b/src/server/routers/notification.ts
@@ -1,0 +1,86 @@
+/**
+ * Notification tRPC router.
+ *
+ * Provides endpoints for listing, reading, and managing notifications.
+ * All endpoints are org-scoped via orgProcedure middleware.
+ */
+import { z } from 'zod';
+import { router, orgProcedure } from '../trpc';
+
+export const notificationRouter = router({
+  /**
+   * List notifications for the current user.
+   * Returns unread + recent read (last 10) by default.
+   * Pass unreadOnly=true to get only unread notifications.
+   */
+  list: orgProcedure
+    .input(
+      z
+        .object({
+          unreadOnly: z.boolean().optional(),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      let query = ctx.supabase
+        .from('notifications')
+        .select('*')
+        .eq('user_id', ctx.user.id)
+        .order('created_at', { ascending: false })
+        .limit(20);
+
+      if (input?.unreadOnly) {
+        query = query.is('read_at', null);
+      }
+
+      const { data: notifications } = await query;
+
+      // Get unread count separately for the badge
+      const { count: unreadCount } = await ctx.supabase
+        .from('notifications')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', ctx.user.id)
+        .is('read_at', null);
+
+      return {
+        notifications: notifications ?? [],
+        unreadCount: unreadCount ?? 0,
+      };
+    }),
+
+  /**
+   * Mark a single notification as read.
+   */
+  markRead: orgProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase
+        .from('notifications')
+        .update({ read_at: new Date().toISOString() })
+        .eq('id', input.id)
+        .eq('user_id', ctx.user.id);
+
+      if (error) {
+        throw new Error(`Failed to mark notification as read: ${error.message}`);
+      }
+
+      return { success: true };
+    }),
+
+  /**
+   * Mark all notifications as read for the current user.
+   */
+  markAllRead: orgProcedure.mutation(async ({ ctx }) => {
+    const { error } = await ctx.supabase
+      .from('notifications')
+      .update({ read_at: new Date().toISOString() })
+      .eq('user_id', ctx.user.id)
+      .is('read_at', null);
+
+    if (error) {
+      throw new Error(`Failed to mark all notifications as read: ${error.message}`);
+    }
+
+    return { success: true };
+  }),
+});

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -62,6 +62,25 @@ export interface CallOut {
 
 export type ClaimStatus = 'pending' | 'approved' | 'rejected';
 
+export type NotificationType =
+  | 'swap_request'
+  | 'swap_approved'
+  | 'swap_denied'
+  | 'shift_claimed'
+  | 'general';
+
+export interface Notification {
+  id: string;
+  org_id: string;
+  user_id: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  link: string | null;
+  read_at: string | null;
+  created_at: string;
+}
+
 export interface Claim {
   id: string;
   callout_id: string;
@@ -126,6 +145,11 @@ export interface Database {
         Row: Claim;
         Insert: Omit<Claim, 'id' | 'created_at' | 'claimed_at'>;
         Update: Partial<Omit<Claim, 'id'>>;
+      };
+      notifications: {
+        Row: Notification;
+        Insert: Omit<Notification, 'id' | 'created_at'>;
+        Update: Partial<Omit<Notification, 'id'>>;
       };
     };
   };

--- a/supabase/migrations/003_notifications.sql
+++ b/supabase/migrations/003_notifications.sql
@@ -1,0 +1,58 @@
+-- Notifications table for in-app notification system
+-- Supports swap event triggers and future email integration
+
+CREATE TABLE public.notifications (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  org_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL CHECK (type IN (
+    'swap_request',
+    'swap_approved',
+    'swap_denied',
+    'shift_claimed',
+    'general'
+  )),
+  title TEXT NOT NULL,
+  message TEXT NOT NULL,
+  link TEXT,                          -- deep link to relevant page (e.g. /callouts/abc)
+  read_at TIMESTAMPTZ,               -- NULL = unread
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for performance
+CREATE INDEX idx_notifications_user_unread
+  ON public.notifications(user_id, created_at DESC)
+  WHERE read_at IS NULL;
+
+CREATE INDEX idx_notifications_user_recent
+  ON public.notifications(user_id, created_at DESC);
+
+CREATE INDEX idx_notifications_org_id
+  ON public.notifications(org_id);
+
+-- Enable RLS
+ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies: users can only see their own notifications within their org
+CREATE POLICY "Users can view own notifications"
+  ON public.notifications FOR SELECT
+  USING (
+    user_id = auth.uid()
+    AND org_id = current_setting('app.current_org_id', true)::uuid
+  );
+
+-- Users can update (mark read) their own notifications
+CREATE POLICY "Users can update own notifications"
+  ON public.notifications FOR UPDATE
+  USING (
+    user_id = auth.uid()
+    AND org_id = current_setting('app.current_org_id', true)::uuid
+  );
+
+-- Server-side insert (via service role or RLS bypass for triggers)
+-- Application code inserts notifications using org context
+CREATE POLICY "Service can insert notifications"
+  ON public.notifications FOR INSERT
+  WITH CHECK (
+    org_id = current_setting('app.current_org_id', true)::uuid
+  );


### PR DESCRIPTION
## Summary
- **Notifications table** (`003_notifications.sql`): org-scoped with RLS policies, unread/recent indexes
- **tRPC endpoints**: `notification.list()`, `notification.markRead(id)`, `notification.markAllRead()` — all org-scoped via `orgProcedure`
- **NotificationDropdown component**: Bell icon in dashboard header with unread count badge, dropdown showing last 10 notifications with click-to-navigate, auto-polls every 30s
- **Swap event triggers**: `notifySwapRequested()`, `notifySwapApproved()`, `notifySwapDenied()` helpers ready to be called from swap workflows
- **Email stub**: `sendEmail()` function with `ENABLE_EMAIL` env var (default OFF), logs to console — ready for Resend/SendGrid integration
- **tRPC client setup**: React Query provider + tRPC hooks for client-side components

## New files
| File | Purpose |
|------|---------|
| `supabase/migrations/003_notifications.sql` | Notifications table + RLS |
| `src/server/routers/notification.ts` | tRPC notification router |
| `src/lib/notifications.ts` | Notification service + email stub |
| `src/lib/trpc.ts` | tRPC React client hooks |
| `src/components/TRPCProvider.tsx` | tRPC + React Query provider |
| `src/components/NotificationDropdown.tsx` | Bell icon + dropdown UI |
| `src/app/dashboard/NotificationBell.tsx` | Provider wrapper for dashboard |
| `src/lib/__tests__/notifications.test.ts` | 8 unit tests |

## Test plan
- [x] All 20 tests pass (12 existing + 8 new)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Run migration on Supabase
- [ ] Verify bell icon renders in dashboard header
- [ ] Test notification creation via trigger helpers
- [ ] Verify mark-read and mark-all-read functionality

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)