### PR TITLE
feat: add schedule calendar and swap requests pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,14 @@
         "@trpc/client": "^11.10.0",
         "@trpc/react-query": "^11.10.0",
         "@trpc/server": "^11.10.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.563.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "superjson": "^2.2.6",
+        "tailwind-merge": "^3.4.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -3734,11 +3738,32 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -6130,6 +6155,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.563.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
+      "integrity": "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7479,6 +7513,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,14 @@
     "@trpc/client": "^11.10.0",
     "@trpc/react-query": "^11.10.0",
     "@trpc/server": "^11.10.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.563.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "superjson": "^2.2.6",
+    "tailwind-merge": "^3.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/app/api/shifts/route.ts
+++ b/src/app/api/shifts/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const startDate = searchParams.get('startDate');
+  const endDate = searchParams.get('endDate');
+  const department = searchParams.get('department');
+
+  let query = supabase
+    .from('shifts')
+    .select('*, user:users(id, name, email, role, department)');
+
+  if (startDate) {
+    query = query.gte('date', startDate);
+  }
+  if (endDate) {
+    query = query.lte('date', endDate);
+  }
+  if (department) {
+    query = query.eq('department', department);
+  }
+
+  query = query.order('date', { ascending: true }).order('start_time', { ascending: true });
+
+  const { data: shifts, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ shifts: shifts ?? [] });
+}

--- a/src/app/api/swaps/route.ts
+++ b/src/app/api/swaps/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { SwapRequest, User } from '@/types/database';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+// Helper for swap_requests queries since the table isn't in the generated types
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function swapTable(supabase: SupabaseClient<any>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (supabase as any).from('swap_requests');
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { id, action } = body as { id: string; action: 'approve' | 'deny' | 'cancel' };
+
+  if (!id || !action) {
+    return NextResponse.json({ error: 'Missing id or action' }, { status: 400 });
+  }
+
+  // Fetch the swap request first
+  const { data: swapRequest } = await swapTable(supabase)
+    .select('*')
+    .eq('id', id)
+    .single() as { data: SwapRequest | null };
+
+  if (!swapRequest) {
+    return NextResponse.json({ error: 'Swap request not found' }, { status: 404 });
+  }
+
+  if (swapRequest.status !== 'pending') {
+    return NextResponse.json(
+      { error: 'Swap request is no longer pending' },
+      { status: 400 }
+    );
+  }
+
+  if (action === 'cancel') {
+    if (swapRequest.requested_by !== user.id) {
+      return NextResponse.json(
+        { error: 'Only the requester can cancel this request' },
+        { status: 403 }
+      );
+    }
+
+    const { data, error } = await swapTable(supabase)
+      .update({ status: 'cancelled' })
+      .eq('id', id)
+      .select()
+      .single() as { data: SwapRequest | null; error: { message: string } | null };
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ swapRequest: data });
+  }
+
+  if (action === 'approve' || action === 'deny') {
+    const { data: profile } = (await supabase
+      .from('users')
+      .select('*')
+      .eq('id', user.id)
+      .single()) as { data: User | null };
+
+    if (!profile || (profile.role !== 'manager' && profile.role !== 'admin')) {
+      return NextResponse.json(
+        { error: 'Only managers can approve or deny swap requests' },
+        { status: 403 }
+      );
+    }
+
+    const newStatus = action === 'approve' ? 'approved' : 'denied';
+
+    const { data, error } = await swapTable(supabase)
+      .update({
+        status: newStatus,
+        reviewed_by: user.id,
+        reviewed_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select()
+      .single() as { data: SwapRequest | null; error: { message: string } | null };
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ swapRequest: data });
+  }
+
+  return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+}

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,0 +1,74 @@
+import { requireAuth } from '@/lib/auth';
+import { createClient } from '@/lib/supabase/server';
+import { Shift, User } from '@/types/database';
+import { ScheduleCalendar } from './schedule-calendar';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SchedulePage() {
+  const session = await requireAuth();
+  const supabase = await createClient();
+
+  // Get current week's date range (Monday to Sunday)
+  const now = new Date();
+  const dayOfWeek = now.getDay();
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - (dayOfWeek === 0 ? 6 : dayOfWeek - 1));
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+
+  const startDate = monday.toISOString().split('T')[0];
+  const endDate = sunday.toISOString().split('T')[0];
+
+  // Fetch shifts for the current week with user details
+  const { data: shifts } = await supabase
+    .from('shifts')
+    .select('*, user:users(id, name, email, role, department)')
+    .gte('date', startDate)
+    .lte('date', endDate)
+    .order('date', { ascending: true })
+    .order('start_time', { ascending: true }) as {
+    data: (Shift & { user: Pick<User, 'id' | 'name' | 'email' | 'role' | 'department'> })[] | null;
+  };
+
+  // Get unique departments for filtering
+  const departments = Array.from(
+    new Set((shifts ?? []).map((s) => s.department).filter(Boolean))
+  ).sort();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+          <h1 className="text-2xl font-bold text-gray-900">ShiftSwap</h1>
+          <div className="flex items-center gap-4">
+            <span className="text-gray-600">
+              {session.name || session.email}
+              <span className="ml-2 px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded">
+                {session.role}
+              </span>
+            </span>
+            <form action="/auth/logout" method="POST">
+              <button
+                type="submit"
+                className="text-sm text-gray-500 hover:text-gray-700"
+              >
+                Sign out
+              </button>
+            </form>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 py-8">
+        <ScheduleCalendar
+          initialShifts={shifts ?? []}
+          departments={departments}
+          currentUserId={session.id}
+          userRole={session.role}
+          initialStartDate={startDate}
+        />
+      </main>
+    </div>
+  );
+}

--- a/src/app/schedule/schedule-calendar.tsx
+++ b/src/app/schedule/schedule-calendar.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { ChevronLeft, ChevronRight, Plus, ArrowLeftRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import { Shift, User, UserRole } from '@/types/database';
+
+type ShiftWithUser = Shift & {
+  user: Pick<User, 'id' | 'name' | 'email' | 'role' | 'department'>;
+};
+
+interface ScheduleCalendarProps {
+  initialShifts: ShiftWithUser[];
+  departments: string[];
+  currentUserId: string;
+  userRole: UserRole;
+  initialStartDate: string;
+}
+
+const ROLE_COLORS: Record<string, string> = {
+  nurse: 'bg-blue-100 border-blue-300 text-blue-800',
+  doctor: 'bg-purple-100 border-purple-300 text-purple-800',
+  tech: 'bg-green-100 border-green-300 text-green-800',
+  admin: 'bg-orange-100 border-orange-300 text-orange-800',
+  receptionist: 'bg-pink-100 border-pink-300 text-pink-800',
+  default: 'bg-gray-100 border-gray-300 text-gray-800',
+};
+
+const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function getWeekDates(startDate: string): Date[] {
+  const start = new Date(startDate + 'T00:00:00');
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    return d;
+  });
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function getRoleColor(role: string): string {
+  return ROLE_COLORS[role.toLowerCase()] || ROLE_COLORS.default;
+}
+
+export function ScheduleCalendar({
+  initialShifts,
+  departments,
+  currentUserId,
+  userRole,
+  initialStartDate,
+}: ScheduleCalendarProps) {
+  const [shifts, setShifts] = useState<ShiftWithUser[]>(initialShifts);
+  const [weekStart, setWeekStart] = useState(initialStartDate);
+  const [selectedDepartment, setSelectedDepartment] = useState('');
+  const [selectedShift, setSelectedShift] = useState<ShiftWithUser | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const weekDates = useMemo(() => getWeekDates(weekStart), [weekStart]);
+  const isManager = userRole === 'manager' || userRole === 'admin';
+
+  const filteredShifts = useMemo(() => {
+    if (!selectedDepartment) return shifts;
+    return shifts.filter((s) => s.department === selectedDepartment);
+  }, [shifts, selectedDepartment]);
+
+  // Group shifts by date
+  const shiftsByDate = useMemo(() => {
+    const map = new Map<string, ShiftWithUser[]>();
+    for (const date of weekDates) {
+      map.set(formatDate(date), []);
+    }
+    for (const shift of filteredShifts) {
+      const existing = map.get(shift.date);
+      if (existing) {
+        existing.push(shift);
+      }
+    }
+    return map;
+  }, [filteredShifts, weekDates]);
+
+  async function navigateWeek(direction: number) {
+    const start = new Date(weekStart + 'T00:00:00');
+    start.setDate(start.getDate() + direction * 7);
+    const newStart = formatDate(start);
+    const newEnd = new Date(start);
+    newEnd.setDate(start.getDate() + 6);
+
+    setWeekStart(newStart);
+    setIsLoading(true);
+
+    try {
+      const params = new URLSearchParams({
+        startDate: newStart,
+        endDate: formatDate(newEnd),
+      });
+      if (selectedDepartment) {
+        params.set('department', selectedDepartment);
+      }
+      const res = await fetch(`/api/shifts?${params.toString()}`);
+      if (res.ok) {
+        const data = await res.json();
+        setShifts(data.shifts ?? []);
+      }
+    } catch {
+      // Keep existing shifts on error
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function goToToday() {
+    const now = new Date();
+    const dayOfWeek = now.getDay();
+    const monday = new Date(now);
+    monday.setDate(now.getDate() - (dayOfWeek === 0 ? 6 : dayOfWeek - 1));
+    const newStart = formatDate(monday);
+
+    if (newStart !== weekStart) {
+      setWeekStart(newStart);
+      // Refetch would happen via navigateWeek, but for today we reload
+      window.location.href = '/schedule';
+    }
+  }
+
+  const weekLabel = useMemo(() => {
+    const start = weekDates[0];
+    const end = weekDates[6];
+    const startMonth = start.toLocaleDateString('en-US', { month: 'long' });
+    const endMonth = end.toLocaleDateString('en-US', { month: 'long' });
+    const year = end.getFullYear();
+    if (startMonth === endMonth) {
+      return `${startMonth} ${start.getDate()} - ${end.getDate()}, ${year}`;
+    }
+    return `${start.toLocaleDateString('en-US', { month: 'short' })} ${start.getDate()} - ${end.toLocaleDateString('en-US', { month: 'short' })} ${end.getDate()}, ${year}`;
+  }, [weekDates]);
+
+  return (
+    <div>
+      {/* Toolbar */}
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">Schedule</h2>
+          <p className="text-sm text-gray-500">{weekLabel}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Select
+            options={departments.map((d) => ({ value: d, label: d }))}
+            placeholder="All Departments"
+            value={selectedDepartment}
+            onChange={(e) => setSelectedDepartment(e.target.value)}
+            className="w-44"
+          />
+          <div className="flex items-center gap-1">
+            <Button variant="outline" size="icon" onClick={() => navigateWeek(-1)} disabled={isLoading}>
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button variant="outline" size="sm" onClick={goToToday}>
+              Today
+            </Button>
+            <Button variant="outline" size="icon" onClick={() => navigateWeek(1)} disabled={isLoading}>
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+          {isManager && (
+            <Button size="sm">
+              <Plus className="h-4 w-4 mr-1" />
+              Create Shift
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Calendar grid */}
+      <div className="bg-white rounded-lg shadow overflow-hidden">
+        {/* Day headers */}
+        <div className="grid grid-cols-7 border-b border-gray-200">
+          {weekDates.map((date, i) => {
+            const isToday = formatDate(date) === formatDate(new Date());
+            return (
+              <div
+                key={i}
+                className={`px-2 py-3 text-center border-r border-gray-200 last:border-r-0 ${
+                  isToday ? 'bg-blue-50' : ''
+                }`}
+              >
+                <div className="text-xs font-medium text-gray-500 uppercase">
+                  {DAY_NAMES[i]}
+                </div>
+                <div
+                  className={`text-sm font-semibold mt-1 ${
+                    isToday
+                      ? 'bg-blue-600 text-white rounded-full w-7 h-7 flex items-center justify-center mx-auto'
+                      : 'text-gray-900'
+                  }`}
+                >
+                  {date.getDate()}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Shift cells */}
+        <div className="grid grid-cols-7 min-h-[400px]">
+          {weekDates.map((date, i) => {
+            const dateStr = formatDate(date);
+            const dayShifts = shiftsByDate.get(dateStr) ?? [];
+            const isToday = dateStr === formatDate(new Date());
+
+            return (
+              <div
+                key={i}
+                className={`border-r border-gray-200 last:border-r-0 p-2 space-y-1.5 ${
+                  isToday ? 'bg-blue-50/30' : ''
+                }`}
+              >
+                {isLoading ? (
+                  <div className="flex items-center justify-center h-20">
+                    <div className="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+                  </div>
+                ) : dayShifts.length === 0 ? (
+                  <div className="text-xs text-gray-400 text-center py-4">
+                    No shifts
+                  </div>
+                ) : (
+                  dayShifts.map((shift) => (
+                    <button
+                      key={shift.id}
+                      onClick={() => setSelectedShift(shift)}
+                      className={`w-full text-left p-2 rounded-md border text-xs transition-shadow hover:shadow-md ${getRoleColor(
+                        shift.role
+                      )}`}
+                    >
+                      <div className="font-semibold truncate">
+                        {shift.start_time} - {shift.end_time}
+                      </div>
+                      <div className="truncate">{shift.user?.name || 'Unassigned'}</div>
+                      <div className="truncate opacity-75">{shift.role}</div>
+                    </button>
+                  ))
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Shift detail modal */}
+      <Dialog open={!!selectedShift} onOpenChange={() => setSelectedShift(null)}>
+        {selectedShift && (
+          <DialogContent onClose={() => setSelectedShift(null)}>
+            <DialogHeader>
+              <DialogTitle>Shift Details</DialogTitle>
+              <DialogDescription>
+                {new Date(selectedShift.date + 'T00:00:00').toLocaleDateString('en-US', {
+                  weekday: 'long',
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="text-xs font-medium text-gray-500 uppercase">Time</label>
+                  <p className="text-sm font-medium">
+                    {selectedShift.start_time} - {selectedShift.end_time}
+                  </p>
+                </div>
+                <div>
+                  <label className="text-xs font-medium text-gray-500 uppercase">Role</label>
+                  <p className="text-sm">
+                    <Badge variant="info">{selectedShift.role}</Badge>
+                  </p>
+                </div>
+                <div>
+                  <label className="text-xs font-medium text-gray-500 uppercase">Department</label>
+                  <p className="text-sm font-medium">{selectedShift.department}</p>
+                </div>
+                <div>
+                  <label className="text-xs font-medium text-gray-500 uppercase">Assignee</label>
+                  <p className="text-sm font-medium">
+                    {selectedShift.user?.name || 'Unassigned'}
+                  </p>
+                </div>
+              </div>
+
+              {selectedShift.user?.email && (
+                <div>
+                  <label className="text-xs font-medium text-gray-500 uppercase">Email</label>
+                  <p className="text-sm text-gray-600">{selectedShift.user.email}</p>
+                </div>
+              )}
+            </div>
+
+            <DialogFooter>
+              {selectedShift.user_id === currentUserId && (
+                <a
+                  href={`/swaps?shiftId=${selectedShift.id}`}
+                  className="inline-flex items-center justify-center h-8 rounded-md px-3 text-xs font-medium border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 transition-colors"
+                >
+                  <ArrowLeftRight className="h-4 w-4 mr-1" />
+                  Request Swap
+                </a>
+              )}
+              <Button variant="outline" size="sm" onClick={() => setSelectedShift(null)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/swaps/page.tsx
+++ b/src/app/swaps/page.tsx
@@ -1,0 +1,54 @@
+import { requireAuth } from '@/lib/auth';
+import { createClient } from '@/lib/supabase/server';
+import { SwapRequestsList } from './swap-requests-list';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SwapsPage() {
+  const session = await requireAuth();
+  const supabase = await createClient();
+
+  // Fetch swap requests with related data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: swapRequests } = (await (supabase as any)
+    .from('swap_requests')
+    .select(
+      '*, shift:shifts(id, date, start_time, end_time, role, department, user_id), requester:users!swap_requests_requested_by_fkey(id, name, email, role, department)'
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .order('created_at', { ascending: false })) as { data: any[] | null };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+          <h1 className="text-2xl font-bold text-gray-900">ShiftSwap</h1>
+          <div className="flex items-center gap-4">
+            <span className="text-gray-600">
+              {session.name || session.email}
+              <span className="ml-2 px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded">
+                {session.role}
+              </span>
+            </span>
+            <form action="/auth/logout" method="POST">
+              <button
+                type="submit"
+                className="text-sm text-gray-500 hover:text-gray-700"
+              >
+                Sign out
+              </button>
+            </form>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 py-8">
+        <SwapRequestsList
+          initialRequests={swapRequests ?? []}
+          currentUserId={session.id}
+          userRole={session.role}
+        />
+      </main>
+    </div>
+  );
+}

--- a/src/app/swaps/swap-requests-list.tsx
+++ b/src/app/swaps/swap-requests-list.tsx
@@ -1,0 +1,426 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, X, Clock, ArrowLeftRight, Eye } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge, type BadgeProps } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { UserRole, SwapRequestStatus } from '@/types/database';
+
+interface SwapRequestData {
+  id: string;
+  org_id: string;
+  shift_id: string;
+  requested_by: string;
+  reason: string | null;
+  status: SwapRequestStatus;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+  updated_at: string;
+  shift: {
+    id: string;
+    date: string;
+    start_time: string;
+    end_time: string;
+    role: string;
+    department: string;
+    user_id: string;
+  };
+  requester: {
+    id: string;
+    name: string;
+    email: string;
+    role: string;
+    department: string | null;
+  };
+}
+
+interface SwapRequestsListProps {
+  initialRequests: SwapRequestData[];
+  currentUserId: string;
+  userRole: UserRole;
+}
+
+const STATUS_BADGE_MAP: Record<SwapRequestStatus, BadgeProps['variant']> = {
+  pending: 'pending',
+  approved: 'approved',
+  denied: 'denied',
+  cancelled: 'cancelled',
+};
+
+function formatShiftDate(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function SwapRequestsList({
+  initialRequests,
+  currentUserId,
+  userRole,
+}: SwapRequestsListProps) {
+  const [requests, setRequests] = useState<SwapRequestData[]>(initialRequests);
+  const [selectedRequest, setSelectedRequest] = useState<SwapRequestData | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [filter, setFilter] = useState<'all' | 'pending' | 'mine'>('all');
+
+  const isManager = userRole === 'manager' || userRole === 'admin';
+
+  const filteredRequests = requests.filter((req) => {
+    if (filter === 'pending') return req.status === 'pending';
+    if (filter === 'mine') return req.requested_by === currentUserId;
+    return true;
+  });
+
+  const pendingCount = requests.filter((r) => r.status === 'pending').length;
+  const myRequestsCount = requests.filter((r) => r.requested_by === currentUserId).length;
+
+  async function handleAction(id: string, action: 'approve' | 'deny' | 'cancel') {
+    setActionLoading(id);
+    try {
+      const res = await fetch('/api/swaps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, action }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        setRequests((prev) =>
+          prev.map((r) =>
+            r.id === id ? { ...r, status: data.swapRequest.status, reviewed_by: data.swapRequest.reviewed_by, reviewed_at: data.swapRequest.reviewed_at } : r
+          )
+        );
+        setSelectedRequest(null);
+      }
+    } catch {
+      // Error handling - keep current state
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  return (
+    <div>
+      {/* Page header with filters */}
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 flex items-center gap-2">
+            <ArrowLeftRight className="h-5 w-5" />
+            Swap Requests
+          </h2>
+          <p className="text-sm text-gray-500">
+            {pendingCount} pending {pendingCount === 1 ? 'request' : 'requests'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant={filter === 'all' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setFilter('all')}
+          >
+            All ({requests.length})
+          </Button>
+          <Button
+            variant={filter === 'pending' ? 'warning' : 'outline'}
+            size="sm"
+            onClick={() => setFilter('pending')}
+          >
+            <Clock className="h-3 w-3 mr-1" />
+            Pending ({pendingCount})
+          </Button>
+          <Button
+            variant={filter === 'mine' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setFilter('mine')}
+          >
+            My Requests ({myRequestsCount})
+          </Button>
+        </div>
+      </div>
+
+      {/* Manager approval queue */}
+      {isManager && pendingCount > 0 && filter !== 'mine' && (
+        <Card className="mb-6 border-yellow-200 bg-yellow-50">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base text-yellow-800">
+              Pending Approvals
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {requests
+                .filter((r) => r.status === 'pending')
+                .map((req) => (
+                  <div
+                    key={req.id}
+                    className="flex items-center justify-between bg-white rounded-lg p-3 border border-yellow-200"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-sm truncate">
+                          {req.requester?.name || 'Unknown'}
+                        </span>
+                        <Badge variant="pending">Pending</Badge>
+                      </div>
+                      <div className="text-xs text-gray-500 mt-0.5">
+                        {req.shift
+                          ? `${formatShiftDate(req.shift.date)} ${req.shift.start_time}-${req.shift.end_time} (${req.shift.role})`
+                          : 'Shift details unavailable'}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 ml-4">
+                      <Button
+                        variant="success"
+                        size="sm"
+                        onClick={() => handleAction(req.id, 'approve')}
+                        disabled={actionLoading === req.id}
+                      >
+                        <Check className="h-3 w-3 mr-1" />
+                        Approve
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleAction(req.id, 'deny')}
+                        disabled={actionLoading === req.id}
+                      >
+                        <X className="h-3 w-3 mr-1" />
+                        Deny
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* All requests list */}
+      {filteredRequests.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <ArrowLeftRight className="h-12 w-12 text-gray-300 mx-auto mb-3" />
+            <p className="text-gray-500">No swap requests found.</p>
+            {filter !== 'all' && (
+              <Button
+                variant="link"
+                size="sm"
+                onClick={() => setFilter('all')}
+                className="mt-2"
+              >
+                View all requests
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {filteredRequests.map((req) => (
+            <Card key={req.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="py-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="font-medium text-sm">
+                        {req.requester?.name || 'Unknown'}
+                      </span>
+                      <Badge variant={STATUS_BADGE_MAP[req.status]}>
+                        {req.status}
+                      </Badge>
+                      {req.requested_by === currentUserId && (
+                        <span className="text-xs text-blue-600 font-medium">(You)</span>
+                      )}
+                    </div>
+                    <div className="text-sm text-gray-600">
+                      {req.shift
+                        ? `${formatShiftDate(req.shift.date)} | ${req.shift.start_time} - ${req.shift.end_time} | ${req.shift.role} - ${req.shift.department}`
+                        : 'Shift details unavailable'}
+                    </div>
+                    {req.reason && (
+                      <p className="text-xs text-gray-500 mt-1 truncate">
+                        Reason: {req.reason}
+                      </p>
+                    )}
+                    <p className="text-xs text-gray-400 mt-1">
+                      Submitted {new Date(req.created_at).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: 'numeric',
+                        minute: '2-digit',
+                      })}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 ml-4">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setSelectedRequest(req)}
+                    >
+                      <Eye className="h-4 w-4" />
+                    </Button>
+                    {isManager && req.status === 'pending' && (
+                      <>
+                        <Button
+                          variant="success"
+                          size="sm"
+                          onClick={() => handleAction(req.id, 'approve')}
+                          disabled={actionLoading === req.id}
+                        >
+                          <Check className="h-3 w-3" />
+                        </Button>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => handleAction(req.id, 'deny')}
+                          disabled={actionLoading === req.id}
+                        >
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </>
+                    )}
+                    {req.requested_by === currentUserId && req.status === 'pending' && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleAction(req.id, 'cancel')}
+                        disabled={actionLoading === req.id}
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Detail modal */}
+      <Dialog open={!!selectedRequest} onOpenChange={() => setSelectedRequest(null)}>
+        {selectedRequest && (
+          <DialogContent onClose={() => setSelectedRequest(null)}>
+            <DialogHeader>
+              <DialogTitle>Swap Request Details</DialogTitle>
+              <DialogDescription>
+                Request #{selectedRequest.id.slice(0, 8)}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">Status:</span>
+                <Badge variant={STATUS_BADGE_MAP[selectedRequest.status]}>
+                  {selectedRequest.status}
+                </Badge>
+              </div>
+
+              <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+                <h4 className="text-sm font-semibold text-gray-700">Shift Information</h4>
+                {selectedRequest.shift && (
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <div>
+                      <span className="text-gray-500">Date</span>
+                      <p className="font-medium">{formatShiftDate(selectedRequest.shift.date)}</p>
+                    </div>
+                    <div>
+                      <span className="text-gray-500">Time</span>
+                      <p className="font-medium">
+                        {selectedRequest.shift.start_time} - {selectedRequest.shift.end_time}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-gray-500">Role</span>
+                      <p className="font-medium">{selectedRequest.shift.role}</p>
+                    </div>
+                    <div>
+                      <span className="text-gray-500">Department</span>
+                      <p className="font-medium">{selectedRequest.shift.department}</p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="bg-gray-50 rounded-lg p-4 space-y-2">
+                <h4 className="text-sm font-semibold text-gray-700">Requester</h4>
+                {selectedRequest.requester && (
+                  <div className="text-sm">
+                    <p className="font-medium">{selectedRequest.requester.name}</p>
+                    <p className="text-gray-500">{selectedRequest.requester.email}</p>
+                    {selectedRequest.requester.department && (
+                      <p className="text-gray-500">{selectedRequest.requester.department}</p>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {selectedRequest.reason && (
+                <div>
+                  <span className="text-sm font-semibold text-gray-700">Reason</span>
+                  <p className="text-sm text-gray-600 mt-1">{selectedRequest.reason}</p>
+                </div>
+              )}
+
+              {selectedRequest.reviewed_at && (
+                <div className="text-xs text-gray-400">
+                  Reviewed on{' '}
+                  {new Date(selectedRequest.reviewed_at).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                    hour: 'numeric',
+                    minute: '2-digit',
+                  })}
+                </div>
+              )}
+            </div>
+
+            <DialogFooter>
+              {isManager && selectedRequest.status === 'pending' && (
+                <>
+                  <Button
+                    variant="success"
+                    size="sm"
+                    onClick={() => handleAction(selectedRequest.id, 'approve')}
+                    disabled={actionLoading === selectedRequest.id}
+                  >
+                    <Check className="h-4 w-4 mr-1" />
+                    Approve
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => handleAction(selectedRequest.id, 'deny')}
+                    disabled={actionLoading === selectedRequest.id}
+                  >
+                    <X className="h-4 w-4 mr-1" />
+                    Deny
+                  </Button>
+                </>
+              )}
+              {selectedRequest.requested_by === currentUserId &&
+                selectedRequest.status === 'pending' && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleAction(selectedRequest.id, 'cancel')}
+                    disabled={actionLoading === selectedRequest.id}
+                  >
+                    Cancel Request
+                  </Button>
+                )}
+              <Button variant="outline" size="sm" onClick={() => setSelectedRequest(null)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold transition-colors',
+  {
+    variants: {
+      variant: {
+        default: 'bg-gray-100 text-gray-800',
+        pending: 'bg-yellow-100 text-yellow-800',
+        approved: 'bg-green-100 text-green-800',
+        denied: 'bg-red-100 text-red-800',
+        cancelled: 'bg-gray-100 text-gray-500',
+        info: 'bg-blue-100 text-blue-800',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-600 text-white hover:bg-blue-700',
+        destructive: 'bg-red-600 text-white hover:bg-red-700',
+        outline: 'border border-gray-300 bg-white hover:bg-gray-50 text-gray-700',
+        secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200',
+        ghost: 'hover:bg-gray-100 text-gray-700',
+        link: 'text-blue-600 underline-offset-4 hover:underline',
+        success: 'bg-green-600 text-white hover:bg-green-700',
+        warning: 'bg-yellow-500 text-white hover:bg-yellow-600',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-12 rounded-lg px-8 text-base',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border border-gray-200 bg-white shadow-sm', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('text-sm text-gray-500', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  )
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import * as React from 'react';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+function Dialog({ open, onOpenChange, children }: DialogProps) {
+  React.useEffect(() => {
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={() => onOpenChange(false)}
+      />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+const DialogContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & { onClose?: () => void }
+>(({ className, children, onClose, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'relative z-50 w-full max-w-lg rounded-lg bg-white p-6 shadow-lg',
+      className
+    )}
+    onClick={(e) => e.stopPropagation()}
+    {...props}
+  >
+    {children}
+    {onClose && (
+      <button
+        onClick={onClose}
+        className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100 transition-opacity"
+      >
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </button>
+    )}
+  </div>
+));
+DialogContent.displayName = 'DialogContent';
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex flex-col space-y-1.5 mb-4', className)} {...props} />;
+}
+
+function DialogTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />;
+}
+
+function DialogDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('text-sm text-gray-500', className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex justify-end gap-2 mt-4', className)} {...props} />;
+}
+
+export { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  options: { value: string; label: string }[];
+  placeholder?: string;
+}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, options, placeholder, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        className={cn(
+          'flex h-10 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      >
+        {placeholder && (
+          <option value="">{placeholder}</option>
+        )}
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    );
+  }
+);
+Select.displayName = 'Select';
+
+export { Select };

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
-const PROTECTED_PATHS = ['/dashboard', '/callouts', '/shifts', '/approve', '/admin'];
+const PROTECTED_PATHS = ['/dashboard', '/callouts', '/shifts', '/schedule', '/swaps', '/approve', '/admin'];
 const AUTH_PATHS = ['/auth/login', '/auth/signup'];
 
 export async function updateSession(request: NextRequest) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -6,6 +6,7 @@
  * have app.current_org_id set for RLS enforcement.
  */
 import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
 import { router, publicProcedure, authedProcedure, orgProcedure } from '../trpc';
 
 export const appRouter = router({
@@ -55,21 +56,185 @@ export const appRouter = router({
       .input(
         z.object({
           date: z.string().optional(),
+          startDate: z.string().optional(),
+          endDate: z.string().optional(),
           userId: z.string().uuid().optional(),
+          department: z.string().optional(),
         })
       )
       .query(async ({ ctx, input }) => {
-        let query = ctx.supabase.from('shifts').select('*');
+        let query = ctx.supabase.from('shifts').select('*, user:users(id, name, email, role, department)');
 
         if (input.date) {
           query = query.eq('date', input.date);
         }
+        if (input.startDate) {
+          query = query.gte('date', input.startDate);
+        }
+        if (input.endDate) {
+          query = query.lte('date', input.endDate);
+        }
         if (input.userId) {
           query = query.eq('user_id', input.userId);
         }
+        if (input.department) {
+          query = query.eq('department', input.department);
+        }
+
+        query = query.order('date', { ascending: true }).order('start_time', { ascending: true });
 
         const { data: shifts } = await query;
         return { shifts: shifts ?? [] };
+      }),
+  }),
+
+  /** Swap request routes (org-scoped) */
+  swap: router({
+    /** List swap requests */
+    list: orgProcedure
+      .input(
+        z.object({
+          status: z.enum(['pending', 'approved', 'denied', 'cancelled']).optional(),
+          requestedBy: z.string().uuid().optional(),
+        })
+      )
+      .query(async ({ ctx, input }) => {
+        let query = ctx.supabase
+          .from('swap_requests')
+          .select('*, shift:shifts(*, user:users(id, name, email, role, department)), requester:users!swap_requests_requested_by_fkey(id, name, email, role, department), reviewer:users!swap_requests_reviewed_by_fkey(id, name, email)')
+          .order('created_at', { ascending: false });
+
+        if (input.status) {
+          query = query.eq('status', input.status);
+        }
+        if (input.requestedBy) {
+          query = query.eq('requested_by', input.requestedBy);
+        }
+
+        const { data: swapRequests } = await query;
+        return { swapRequests: swapRequests ?? [] };
+      }),
+
+    /** Create a swap request */
+    create: orgProcedure
+      .input(
+        z.object({
+          shiftId: z.string().uuid(),
+          reason: z.string().optional(),
+        })
+      )
+      .mutation(async ({ ctx, input }) => {
+        const { data, error } = await ctx.supabase
+          .from('swap_requests')
+          .insert({
+            org_id: ctx.orgId,
+            shift_id: input.shiftId,
+            requested_by: ctx.user.id,
+            reason: input.reason ?? null,
+            status: 'pending',
+          })
+          .select()
+          .single();
+
+        if (error) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to create swap request: ${error.message}`,
+          });
+        }
+
+        return { swapRequest: data };
+      }),
+
+    /** Approve a swap request (manager only) */
+    approve: orgProcedure
+      .input(z.object({ id: z.string().uuid() }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.orgRole !== 'manager' && ctx.orgRole !== 'admin') {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Only managers can approve swap requests',
+          });
+        }
+
+        const { data, error } = await ctx.supabase
+          .from('swap_requests')
+          .update({
+            status: 'approved',
+            reviewed_by: ctx.user.id,
+            reviewed_at: new Date().toISOString(),
+          })
+          .eq('id', input.id)
+          .eq('status', 'pending')
+          .select()
+          .single();
+
+        if (error) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to approve swap request: ${error.message}`,
+          });
+        }
+
+        return { swapRequest: data };
+      }),
+
+    /** Deny a swap request (manager only) */
+    deny: orgProcedure
+      .input(z.object({ id: z.string().uuid() }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.orgRole !== 'manager' && ctx.orgRole !== 'admin') {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Only managers can deny swap requests',
+          });
+        }
+
+        const { data, error } = await ctx.supabase
+          .from('swap_requests')
+          .update({
+            status: 'denied',
+            reviewed_by: ctx.user.id,
+            reviewed_at: new Date().toISOString(),
+          })
+          .eq('id', input.id)
+          .eq('status', 'pending')
+          .select()
+          .single();
+
+        if (error) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to deny swap request: ${error.message}`,
+          });
+        }
+
+        return { swapRequest: data };
+      }),
+
+    /** Cancel a swap request (requester only) */
+    cancel: orgProcedure
+      .input(z.object({ id: z.string().uuid() }))
+      .mutation(async ({ ctx, input }) => {
+        const { data, error } = await ctx.supabase
+          .from('swap_requests')
+          .update({
+            status: 'cancelled',
+          })
+          .eq('id', input.id)
+          .eq('requested_by', ctx.user.id)
+          .eq('status', 'pending')
+          .select()
+          .single();
+
+        if (error) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to cancel swap request: ${error.message}`,
+          });
+        }
+
+        return { swapRequest: data };
       }),
   }),
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -60,6 +60,27 @@ export interface CallOut {
   updated_at: string;
 }
 
+export type SwapRequestStatus = 'pending' | 'approved' | 'denied' | 'cancelled';
+
+export interface SwapRequest {
+  id: string;
+  org_id: string;
+  shift_id: string;
+  requested_by: string;
+  reason: string | null;
+  status: SwapRequestStatus;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SwapRequestWithDetails extends SwapRequest {
+  shift: Shift;
+  requester: User;
+  reviewer?: User | null;
+}
+
 export type ClaimStatus = 'pending' | 'approved' | 'rejected';
 
 export interface Claim {
@@ -126,6 +147,11 @@ export interface Database {
         Row: Claim;
         Insert: Omit<Claim, 'id' | 'created_at' | 'claimed_at'>;
         Update: Partial<Omit<Claim, 'id'>>;
+      };
+      swap_requests: {
+        Row: SwapRequest;
+        Insert: Omit<SwapRequest, 'id' | 'created_at' | 'updated_at'>;
+        Update: Partial<Omit<SwapRequest, 'id'>>;
       };
     };
   };


### PR DESCRIPTION
## Summary
- **Weekly Calendar View** (`/schedule`): 7-column grid showing shifts color-coded by role, with week navigation, department filter, shift detail modal, and action buttons for managers/staff
- **Swap Requests Page** (`/swaps`): Status badges (pending/approved/denied/cancelled), manager approval queue with one-click approve/deny, request detail dialog, cancel functionality
- **shadcn/ui Components**: Button (with variants), Badge (with status colors), Card, Dialog, Select
- **API**: Extended tRPC router with swap CRUD operations, REST API routes for shifts and swap actions
- **Types**: Added `SwapRequest` and `SwapRequestWithDetails` types to database types

## Test plan
- [ ] Verify `/schedule` displays weekly calendar with proper 7-column layout
- [ ] Test week navigation (previous/next) buttons
- [ ] Test department filter dropdown
- [ ] Click shift card to open detail modal
- [ ] Verify `/swaps` shows swap requests with status badges
- [ ] Test manager approve/deny buttons on pending requests
- [ ] Test cancel button for own pending requests
- [ ] Verify middleware protects `/schedule` and `/swaps` routes

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)