### PR TITLE
fix: ensure Vercel build passes without JWT_SECRET at build time

### DIFF
--- a/src/lib/db-client.ts
+++ b/src/lib/db-client.ts
@@ -89,7 +89,7 @@ function parseSelectString(selectStr: string): {
 
     // Check if this part is an embed: alias:table(columns)
     const embedMatch = trimmed.match(
-      /^(\w+):(\w+)(?:!(\w+))?\((.+)\)$/s
+      /^(\w+):(\w+)(?:!(\w+))?\(([\s\S]+)\)$/
     );
     if (embedMatch) {
       const [, alias, table, fkHint, innerSelect] = embedMatch;
@@ -275,8 +275,8 @@ class QueryBuilder<T = AnyRow> {
   }
 
   /** Make the builder thenable so `await builder` works. */
-  then<TResult1 = { data: T[] | null; error: unknown; count?: number }, TResult2 = never>(
-    resolve?: ((value: { data: T[] | null; error: unknown; count?: number }) => TResult1 | PromiseLike<TResult1>) | null,
+  then<TResult1 = { data: T[] | null; error: { message: string } | null; count?: number }, TResult2 = never>(
+    resolve?: ((value: { data: T[] | null; error: { message: string } | null; count?: number }) => TResult1 | PromiseLike<TResult1>) | null,
     reject?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
   ): Promise<TResult1 | TResult2> {
     return this.execute().then(resolve, reject);


### PR DESCRIPTION
## Summary

- **jwt.ts `getSecret()` calls are already lazy** — called inside `signAccessToken`/`signRefreshToken`/`verifyToken`, not at module import time. No changes needed there.
- **Fixed two TypeScript build errors in `db-client.ts`** that were preventing the Next.js build from completing:
  1. Replaced regex `/s` flag with `[\s\S]` for ES2017 target compatibility
  2. Typed `QueryBuilder.then()` error as `{ message: string } | null` instead of `unknown` so downstream `.message` access compiles

## Test plan

- [x] `npx next build` succeeds without `JWT_SECRET` env var
- [x] All 156 tests pass (`npx vitest run`)
- [x] Runtime auth still validates `JWT_SECRET` exists (throws if missing when signing/verifying tokens)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)