### PR TITLE
feat: build call-out posting UI

### DIFF
--- a/src/app/callouts/CallOutsList.tsx
+++ b/src/app/callouts/CallOutsList.tsx
@@ -1,0 +1,368 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { trpc } from '@/trpc/client';
+
+interface CallOutShift {
+  id: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+  role: string;
+  department: string;
+  user: { id: string; name: string; email: string } | null;
+}
+
+interface CallOutUser {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface CallOutWithDetails {
+  id: string;
+  shift_id: string;
+  user_id: string;
+  reason: string | null;
+  posted_at: string;
+  status: 'open' | 'claimed' | 'approved' | 'cancelled';
+  created_at: string;
+  shift: CallOutShift | null;
+  user: CallOutUser | null;
+}
+
+const STATUS_BADGES: Record<string, { bg: string; text: string; dot: string }> = {
+  open: { bg: 'bg-amber-50', text: 'text-amber-700', dot: 'bg-amber-400' },
+  claimed: { bg: 'bg-blue-50', text: 'text-blue-700', dot: 'bg-blue-400' },
+  approved: { bg: 'bg-emerald-50', text: 'text-emerald-700', dot: 'bg-emerald-400' },
+  cancelled: { bg: 'bg-gray-100', text: 'text-gray-600', dot: 'bg-gray-400' },
+};
+
+function formatTime(timeStr: string): string {
+  const [h, m] = timeStr.split(':');
+  const hour = parseInt(h, 10);
+  const ampm = hour >= 12 ? 'PM' : 'AM';
+  const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return `${h12}:${m} ${ampm}`;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const badge = STATUS_BADGES[status] ?? STATUS_BADGES.cancelled;
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium border ${badge.bg} ${badge.text} border-current/10`}
+    >
+      <span className={`w-1.5 h-1.5 rounded-full ${badge.dot}`} />
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+type FilterStatus = 'all' | 'open' | 'claimed' | 'approved' | 'cancelled';
+
+interface CallOutsListProps {
+  userId: string;
+}
+
+export function CallOutsList({ userId }: CallOutsListProps) {
+  const [callouts, setCallouts] = useState<CallOutWithDetails[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FilterStatus>('open');
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const fetchCallouts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const input =
+        filter === 'all'
+          ? {}
+          : { status: filter as 'open' | 'claimed' | 'approved' | 'cancelled' };
+      const result = await trpc.callout.list.query(input);
+      setCallouts(result.callouts as CallOutWithDetails[]);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to load call-outs'
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [filter]);
+
+  useEffect(() => {
+    fetchCallouts();
+  }, [fetchCallouts]);
+
+  const handleCancel = async (calloutId: string) => {
+    setCancellingId(calloutId);
+    setActionError(null);
+    try {
+      await trpc.callout.cancel.mutate({ id: calloutId });
+      fetchCallouts();
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to cancel call-out'
+      );
+    } finally {
+      setCancellingId(null);
+    }
+  };
+
+  return (
+    <div>
+      {/* Filter controls */}
+      <div className="flex items-center gap-1.5 mb-6 bg-surface-secondary p-1 rounded-xl border border-border-light w-fit">
+        {(
+          ['all', 'open', 'claimed', 'approved', 'cancelled'] as FilterStatus[]
+        ).map((status) => (
+          <button
+            key={status}
+            onClick={() => setFilter(status)}
+            className={`px-3.5 py-1.5 rounded-lg text-sm font-medium transition-all ${
+              filter === status
+                ? 'bg-surface text-text-primary shadow-sm border border-border'
+                : 'text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {status === 'all'
+              ? 'All'
+              : status.charAt(0).toUpperCase() + status.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm flex items-center gap-2 animate-fade-in-down">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="shrink-0"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {error}
+          <button
+            onClick={fetchCallouts}
+            className="ml-auto text-red-800 underline text-xs font-medium"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {actionError && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm flex items-center gap-2 animate-fade-in-down">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="shrink-0"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {actionError}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="bg-surface rounded-2xl border border-border p-6"
+            >
+              <div className="flex justify-between items-start">
+                <div className="space-y-2.5 flex-1">
+                  <div className="flex items-center gap-3">
+                    <div className="h-4 w-32 rounded-lg animate-shimmer" />
+                    <div className="h-6 w-20 rounded-lg animate-shimmer" />
+                  </div>
+                  <div className="h-3 w-48 rounded-lg animate-shimmer" />
+                  <div className="h-3 w-24 rounded-lg animate-shimmer" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : callouts.length === 0 ? (
+        <div className="bg-surface rounded-2xl border border-border p-12 text-center">
+          <div className="w-14 h-14 rounded-full bg-surface-secondary flex items-center justify-center mx-auto mb-4">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-text-tertiary"
+            >
+              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+              <line x1="12" y1="9" x2="12" y2="13" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          </div>
+          <p className="text-sm text-text-tertiary">
+            {filter === 'open'
+              ? 'No open call-outs right now.'
+              : 'No call-outs found.'}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {callouts.map((callout) => (
+            <CallOutCard
+              key={callout.id}
+              callout={callout}
+              userId={userId}
+              isCancelling={cancellingId === callout.id}
+              onCancel={() => handleCancel(callout.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CallOutCardProps {
+  callout: CallOutWithDetails;
+  userId: string;
+  isCancelling: boolean;
+  onCancel: () => void;
+}
+
+function CallOutCard({
+  callout,
+  userId,
+  isCancelling,
+  onCancel,
+}: CallOutCardProps) {
+  const shift = callout.shift;
+  const isOwn = callout.user_id === userId;
+  const canCancel = isOwn && callout.status === 'open';
+
+  const shiftDate = shift
+    ? new Date(shift.date + 'T00:00:00').toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      })
+    : 'Unknown';
+
+  return (
+    <div className="bg-surface rounded-2xl border border-border p-5 hover:shadow-sm transition-all duration-200">
+      <div className="flex justify-between items-start">
+        <div className="flex-1">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="flex items-center gap-2">
+              <div className="w-7 h-7 rounded-full bg-rose-100 flex items-center justify-center">
+                <span className="text-[10px] font-semibold text-rose-700">
+                  {(callout.user?.name ?? '?').charAt(0).toUpperCase()}
+                </span>
+              </div>
+              <span className="text-sm font-semibold text-text-primary">
+                {callout.user?.name ?? 'Unknown User'}
+              </span>
+            </div>
+            <StatusBadge status={callout.status} />
+            {isOwn && (
+              <span className="text-[11px] text-brand-600 font-medium bg-brand-50 px-1.5 py-0.5 rounded-md border border-brand-200">
+                You
+              </span>
+            )}
+          </div>
+
+          {shift && (
+            <div className="text-sm text-text-secondary mb-1.5 flex items-center gap-1.5">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-text-tertiary shrink-0"
+              >
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+              </svg>
+              <span className="font-medium">{shiftDate}</span> &middot;{' '}
+              {formatTime(shift.start_time)} - {formatTime(shift.end_time)}{' '}
+              &middot; <span className="capitalize">{shift.role}</span> &middot;{' '}
+              {shift.department}
+            </div>
+          )}
+
+          {callout.reason && (
+            <div className="text-sm text-text-secondary mt-1.5">
+              <span className="font-medium text-text-primary">Reason:</span>{' '}
+              {callout.reason}
+            </div>
+          )}
+
+          <div className="text-[11px] text-text-tertiary mt-2.5 flex items-center gap-1">
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <polyline points="12 6 12 12 16 14" />
+            </svg>
+            Posted{' '}
+            {new Date(callout.posted_at || callout.created_at).toLocaleDateString(
+              'en-US',
+              {
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+              }
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 ml-4">
+          {canCancel && (
+            <button
+              onClick={onCancel}
+              disabled={isCancelling}
+              className="px-3.5 py-2 bg-surface-secondary hover:bg-border disabled:opacity-50 text-text-primary rounded-xl text-sm font-medium border border-border transition-all active:scale-[0.98]"
+            >
+              {isCancelling ? 'Cancelling...' : 'Cancel'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/callouts/new/CallOutForm.tsx
+++ b/src/app/callouts/new/CallOutForm.tsx
@@ -1,0 +1,483 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { trpc } from '@/trpc/client';
+
+interface ShiftWithCallout {
+  id: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+  role: string;
+  department: string;
+  has_callout: boolean;
+}
+
+function formatTime(timeStr: string): string {
+  const [h, m] = timeStr.split(':');
+  const hour = parseInt(h, 10);
+  const ampm = hour >= 12 ? 'PM' : 'AM';
+  const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return `${h12}:${m} ${ampm}`;
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+interface CallOutFormProps {
+  userId: string;
+}
+
+export function CallOutForm({ userId }: CallOutFormProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const preselectedShiftId = searchParams.get('shift');
+
+  const [shifts, setShifts] = useState<ShiftWithCallout[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedShiftId, setSelectedShiftId] = useState<string | null>(
+    preselectedShiftId
+  );
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const fetchShifts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await trpc.callout.myShifts.query();
+      setShifts(result.shifts as ShiftWithCallout[]);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to load your shifts'
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchShifts();
+  }, [fetchShifts]);
+
+  // Auto-select the preselected shift once shifts load
+  useEffect(() => {
+    if (preselectedShiftId && shifts.length > 0) {
+      const found = shifts.find((s) => s.id === preselectedShiftId);
+      if (found && !found.has_callout) {
+        setSelectedShiftId(preselectedShiftId);
+      }
+    }
+  }, [preselectedShiftId, shifts]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedShiftId) return;
+
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await trpc.callout.create.mutate({
+        shiftId: selectedShiftId,
+        reason: reason.trim() || undefined,
+      });
+      setSuccess(true);
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err.message : 'Failed to post call-out'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Ignore userId for linting — used to confirm ownership is server-side
+  void userId;
+
+  if (success) {
+    return (
+      <div className="bg-surface rounded-2xl border border-border p-8 text-center animate-scale-in">
+        <div className="w-14 h-14 rounded-full bg-emerald-50 border border-emerald-200 flex items-center justify-center mx-auto mb-4">
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-emerald-600"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+        <h2 className="text-lg font-semibold text-text-primary mb-1">
+          Call-Out Posted
+        </h2>
+        <p className="text-sm text-text-secondary mb-6">
+          Your managers have been notified. Other staff can now pick up this
+          shift.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={() => router.push('/dashboard')}
+            className="px-4 py-2.5 bg-brand-600 hover:bg-brand-700 text-white rounded-xl text-sm font-medium transition-all shadow-sm hover:shadow-md active:scale-[0.98]"
+          >
+            Back to Dashboard
+          </button>
+          <button
+            onClick={() => router.push('/callouts')}
+            className="px-4 py-2.5 bg-surface-secondary hover:bg-border text-text-primary rounded-xl text-sm font-medium border border-border transition-all active:scale-[0.98]"
+          >
+            View Open Call-Outs
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const eligibleShifts = shifts.filter((s) => !s.has_callout);
+  const selectedShift = shifts.find((s) => s.id === selectedShiftId);
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {/* Intro */}
+      <div className="mb-6">
+        <p className="text-sm text-text-secondary">
+          Select the shift you can&apos;t work and optionally add a reason.
+          Your managers will be notified and the shift will be posted for
+          others to pick up.
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm flex items-center gap-2 animate-fade-in-down">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="shrink-0"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {error}
+          <button
+            type="button"
+            onClick={fetchShifts}
+            className="ml-auto text-red-800 underline text-xs font-medium"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {submitError && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm flex items-center gap-2 animate-fade-in-down">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="shrink-0"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {submitError}
+        </div>
+      )}
+
+      {/* Shift Selection */}
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-text-primary mb-3">
+          Select Shift
+        </label>
+
+        {loading ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="bg-surface rounded-2xl border border-border p-5"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-10 h-10 rounded-xl animate-shimmer" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-4 w-32 rounded-lg animate-shimmer" />
+                    <div className="h-3 w-48 rounded-lg animate-shimmer" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : eligibleShifts.length === 0 ? (
+          <div className="bg-surface rounded-2xl border border-border p-8 text-center">
+            <div className="w-12 h-12 rounded-full bg-surface-secondary flex items-center justify-center mx-auto mb-3">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-text-tertiary"
+              >
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+              </svg>
+            </div>
+            <p className="text-sm text-text-tertiary">
+              {shifts.length === 0
+                ? 'No upcoming shifts found.'
+                : 'All your upcoming shifts already have call-outs posted.'}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {eligibleShifts.map((shift, i) => {
+              const isSelected = selectedShiftId === shift.id;
+              return (
+                <button
+                  key={shift.id}
+                  type="button"
+                  onClick={() => setSelectedShiftId(shift.id)}
+                  className={`w-full text-left rounded-2xl border p-4 transition-all duration-200 animate-fade-in-up stagger-${Math.min(i + 1, 5)} ${
+                    isSelected
+                      ? 'border-brand-500 bg-brand-50/50 shadow-sm ring-2 ring-brand-500/20'
+                      : 'border-border bg-surface hover:border-border hover:bg-surface-secondary/50'
+                  }`}
+                >
+                  <div className="flex items-center gap-4">
+                    <div
+                      className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${
+                        isSelected
+                          ? 'bg-brand-100 border border-brand-200'
+                          : 'bg-surface-secondary border border-border-light'
+                      }`}
+                    >
+                      <span
+                        className={`text-xs font-bold ${
+                          isSelected ? 'text-brand-600' : 'text-text-secondary'
+                        }`}
+                      >
+                        {new Date(shift.date + 'T00:00:00').getDate()}
+                      </span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium text-text-primary">
+                        {formatDate(shift.date)}
+                      </div>
+                      <div className="text-xs text-text-secondary mt-0.5">
+                        {formatTime(shift.start_time)} -{' '}
+                        {formatTime(shift.end_time)} &middot;{' '}
+                        <span className="capitalize">{shift.role}</span>{' '}
+                        &middot; {shift.department}
+                      </div>
+                    </div>
+                    <div
+                      className={`w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 transition-all ${
+                        isSelected
+                          ? 'border-brand-500 bg-brand-500'
+                          : 'border-border'
+                      }`}
+                    >
+                      {isSelected && (
+                        <svg
+                          width="10"
+                          height="10"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="white"
+                          strokeWidth="3"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Already called-out shifts */}
+        {shifts.filter((s) => s.has_callout).length > 0 && (
+          <div className="mt-4">
+            <p className="text-xs text-text-tertiary mb-2">
+              Already called out:
+            </p>
+            <div className="space-y-1.5">
+              {shifts
+                .filter((s) => s.has_callout)
+                .map((shift) => (
+                  <div
+                    key={shift.id}
+                    className="flex items-center gap-3 px-4 py-2.5 rounded-xl bg-surface-secondary/50 border border-border-light opacity-60"
+                  >
+                    <div className="w-7 h-7 rounded-lg bg-rose-50 border border-rose-200 flex items-center justify-center">
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="text-rose-500"
+                      >
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    </div>
+                    <div className="text-xs text-text-secondary">
+                      {formatDate(shift.date)} &middot;{' '}
+                      {formatTime(shift.start_time)} -{' '}
+                      {formatTime(shift.end_time)}
+                    </div>
+                    <span className="ml-auto text-[10px] font-medium text-rose-600 bg-rose-50 px-1.5 py-0.5 rounded-md border border-rose-200">
+                      Called out
+                    </span>
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Reason */}
+      <div className="mb-8">
+        <label
+          htmlFor="reason"
+          className="block text-sm font-medium text-text-primary mb-2"
+        >
+          Reason{' '}
+          <span className="text-text-tertiary font-normal">(optional)</span>
+        </label>
+        <textarea
+          id="reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="e.g., Sick, family emergency, doctor's appointment..."
+          rows={3}
+          className="w-full px-4 py-3 bg-surface border border-border rounded-xl text-sm text-text-primary placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-brand-500/20 focus:border-brand-500 transition-all resize-none"
+        />
+      </div>
+
+      {/* Selected shift confirmation */}
+      {selectedShift && !selectedShift.has_callout && (
+        <div className="mb-6 p-4 bg-rose-50/50 border border-rose-200 rounded-xl animate-fade-in">
+          <div className="flex items-start gap-3">
+            <div className="w-8 h-8 rounded-lg bg-rose-100 flex items-center justify-center shrink-0 mt-0.5">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-rose-600"
+              >
+                <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-rose-800">
+                You&apos;re calling out from:
+              </p>
+              <p className="text-sm text-rose-700 mt-0.5">
+                {formatDate(selectedShift.date)} &middot;{' '}
+                {formatTime(selectedShift.start_time)} -{' '}
+                {formatTime(selectedShift.end_time)} &middot;{' '}
+                <span className="capitalize">{selectedShift.role}</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Submit */}
+      <button
+        type="submit"
+        disabled={!selectedShiftId || submitting}
+        className="w-full py-3 bg-rose-600 hover:bg-rose-700 disabled:bg-rose-300 text-white rounded-xl text-sm font-semibold transition-all shadow-sm hover:shadow-md active:scale-[0.98] flex items-center justify-center gap-2"
+      >
+        {submitting ? (
+          <>
+            <svg
+              className="animate-spin h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+            Posting Call-Out...
+          </>
+        ) : (
+          <>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+              <line x1="12" y1="9" x2="12" y2="13" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+            Post Call-Out
+          </>
+        )}
+      </button>
+    </form>
+  );
+}

--- a/src/app/callouts/new/page.tsx
+++ b/src/app/callouts/new/page.tsx
@@ -1,0 +1,66 @@
+import { requireAuth } from '@/lib/auth';
+import Link from 'next/link';
+import { CallOutForm } from './CallOutForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NewCallOutPage() {
+  const session = await requireAuth();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="bg-surface border-b border-border sticky top-0 z-30 backdrop-blur-xl bg-surface/80">
+        <div className="max-w-7xl mx-auto px-6 py-4 flex justify-between items-center">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/dashboard"
+              className="w-8 h-8 rounded-lg bg-surface-secondary border border-border flex items-center justify-center text-text-tertiary hover:text-text-primary hover:bg-border transition-all"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+            </Link>
+            <h1 className="text-lg font-semibold tracking-tight text-text-primary">
+              Post a Call-Out
+            </h1>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/callouts"
+              className="text-sm font-medium text-brand-600 hover:text-brand-700 transition-colors"
+            >
+              Open Call-Outs
+            </Link>
+            <div className="flex items-center gap-2.5">
+              <div className="w-8 h-8 rounded-full bg-brand-100 flex items-center justify-center">
+                <span className="text-xs font-semibold text-brand-700">
+                  {(session.name || session.email || '?').charAt(0).toUpperCase()}
+                </span>
+              </div>
+              <div className="hidden sm:block">
+                <span className="text-sm font-medium text-text-primary">
+                  {session.name || session.email}
+                </span>
+                <span className="ml-2 px-2 py-0.5 text-[11px] font-medium bg-brand-50 text-brand-700 border border-brand-200 rounded-full">
+                  {session.role}
+                </span>
+              </div>
+            </div>
+            <form action="/auth/logout" method="POST">
+              <button
+                type="submit"
+                className="text-sm text-text-tertiary hover:text-text-primary transition-colors"
+              >
+                Sign out
+              </button>
+            </form>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-8 animate-fade-in-up">
+        <CallOutForm userId={session.id} />
+      </main>
+    </div>
+  );
+}

--- a/src/app/callouts/page.tsx
+++ b/src/app/callouts/page.tsx
@@ -1,0 +1,71 @@
+import { requireAuth } from '@/lib/auth';
+import Link from 'next/link';
+import { CallOutsList } from './CallOutsList';
+
+export const dynamic = 'force-dynamic';
+
+export default async function CalloutsPage() {
+  const session = await requireAuth();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="bg-surface border-b border-border sticky top-0 z-30 backdrop-blur-xl bg-surface/80">
+        <div className="max-w-7xl mx-auto px-6 py-4 flex justify-between items-center">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/dashboard"
+              className="w-8 h-8 rounded-lg bg-surface-secondary border border-border flex items-center justify-center text-text-tertiary hover:text-text-primary hover:bg-border transition-all"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+            </Link>
+            <h1 className="text-lg font-semibold tracking-tight text-text-primary">
+              Open Call-Outs
+            </h1>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/callouts/new"
+              className="inline-flex items-center gap-1.5 px-3.5 py-2 bg-rose-600 hover:bg-rose-700 text-white rounded-xl text-sm font-medium transition-all shadow-sm hover:shadow-md active:scale-[0.98]"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+              Post Call-Out
+            </Link>
+            <div className="flex items-center gap-2.5">
+              <div className="w-8 h-8 rounded-full bg-brand-100 flex items-center justify-center">
+                <span className="text-xs font-semibold text-brand-700">
+                  {(session.name || session.email || '?').charAt(0).toUpperCase()}
+                </span>
+              </div>
+              <div className="hidden sm:block">
+                <span className="text-sm font-medium text-text-primary">
+                  {session.name || session.email}
+                </span>
+                <span className="ml-2 px-2 py-0.5 text-[11px] font-medium bg-brand-50 text-brand-700 border border-brand-200 rounded-full">
+                  {session.role}
+                </span>
+              </div>
+            </div>
+            <form action="/auth/logout" method="POST">
+              <button
+                type="submit"
+                className="text-sm text-text-tertiary hover:text-text-primary transition-colors"
+              >
+                Sign out
+              </button>
+            </form>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-6 py-6 animate-fade-in-up">
+        <CallOutsList userId={session.id} />
+      </main>
+    </div>
+  );
+}

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -5,11 +5,11 @@
  * applied via orgProcedure, so all org-scoped queries automatically
  * have app.current_org_id set for RLS enforcement.
  */
-import { z } from 'zod';
 import { router, publicProcedure, authedProcedure, orgProcedure } from '../trpc';
 import { shiftRouter } from './shift';
 import { swapRouter } from './swap';
 import { notificationRouter } from './notification';
+import { calloutRouter } from './callout';
 
 export const appRouter = router({
   /** Health check — public, no auth required */
@@ -62,26 +62,7 @@ export const appRouter = router({
   notification: notificationRouter,
 
   /** Callout routes (org-scoped) */
-  callout: router({
-    list: orgProcedure
-      .input(
-        z.object({
-          status: z
-            .enum(['open', 'claimed', 'approved', 'cancelled'])
-            .optional(),
-        })
-      )
-      .query(async ({ ctx, input }) => {
-        let query = ctx.db.from('callouts').select('*, shift:shifts(*)');
-
-        if (input.status) {
-          query = query.eq('status', input.status);
-        }
-
-        const { data: callouts } = await query;
-        return { callouts: callouts ?? [] };
-      }),
-  }),
+  callout: calloutRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/routers/callout.ts
+++ b/src/server/routers/callout.ts
@@ -1,0 +1,254 @@
+/**
+ * Callout router.
+ *
+ * Handles the call-out posting workflow:
+ * - Staff can view their upcoming shifts eligible for call-out
+ * - Staff can post a call-out on their own shift (status='open')
+ * - Staff can cancel their own open call-outs
+ * - List open call-outs for the org
+ *
+ * Status lifecycle: open → claimed/cancelled (→ approved)
+ */
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { router, orgProcedure } from '../trpc';
+import { createNotification } from '@/lib/notifications';
+
+export const calloutRouter = router({
+  /**
+   * List callouts with optional status filter.
+   * Returns callout records with embedded shift and user details.
+   */
+  list: orgProcedure
+    .input(
+      z.object({
+        status: z
+          .enum(['open', 'claimed', 'approved', 'cancelled'])
+          .optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      let query = ctx.db
+        .from('callouts')
+        .select('*, shift:shifts(*, user:users(id, name, email)), user:users(id, name, email)');
+
+      if (input.status) {
+        query = query.eq('status', input.status);
+      }
+
+      query = query.order('created_at', { ascending: false });
+
+      const { data: callouts, error } = await query;
+      if (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to fetch callouts: ${error.message}`,
+        });
+      }
+      return { callouts: callouts ?? [] };
+    }),
+
+  /**
+   * Get the current user's upcoming shifts that are eligible for call-out.
+   * Filters out shifts that already have an open/claimed callout.
+   */
+  myShifts: orgProcedure.query(async ({ ctx }) => {
+    const today = new Date().toISOString().split('T')[0];
+
+    // Fetch user's upcoming shifts
+    const { data: shifts, error: shiftError } = await ctx.db
+      .from('shifts')
+      .select('*')
+      .eq('user_id', ctx.user.id)
+      .gte('date', today)
+      .order('date')
+      .order('start_time');
+
+    if (shiftError) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `Failed to fetch shifts: ${shiftError.message}`,
+      });
+    }
+
+    if (!shifts || shifts.length === 0) {
+      return { shifts: [] };
+    }
+
+    // Fetch existing open/claimed callouts for these shifts
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shiftIds = shifts.map((s: any) => s.id);
+    const { data: existingCallouts } = await ctx.db
+      .from('callouts')
+      .select('shift_id')
+      .in('shift_id', shiftIds)
+      .in('status', ['open', 'claimed']);
+
+    const calledOutShiftIds = new Set(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (existingCallouts ?? []).map((c: any) => c.shift_id)
+    );
+
+    // Mark which shifts already have callouts
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const enrichedShifts = shifts.map((shift: any) => ({
+      ...shift,
+      has_callout: calledOutShiftIds.has(shift.id),
+    }));
+
+    return { shifts: enrichedShifts };
+  }),
+
+  /**
+   * Post a call-out on a shift.
+   * The user must own the shift, and no open/claimed callout can exist for it.
+   */
+  create: orgProcedure
+    .input(
+      z.object({
+        shiftId: z.string().uuid(),
+        reason: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Verify the shift exists and belongs to the user
+      const { data: shift, error: shiftError } = await ctx.db
+        .from('shifts')
+        .select('*')
+        .eq('id', input.shiftId)
+        .single();
+
+      if (shiftError || !shift) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Shift not found',
+        });
+      }
+
+      if (shift.user_id !== ctx.user.id) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You can only post call-outs for your own shifts',
+        });
+      }
+
+      // Check for existing open/claimed callout on this shift
+      const { data: existing } = await ctx.db
+        .from('callouts')
+        .select('id')
+        .eq('shift_id', input.shiftId)
+        .in('status', ['open', 'claimed']);
+
+      if (existing && existing.length > 0) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'A call-out already exists for this shift',
+        });
+      }
+
+      // Create the callout
+      const { data: callout, error } = await ctx.db
+        .from('callouts')
+        .insert({
+          shift_id: input.shiftId,
+          user_id: ctx.user.id,
+          reason: input.reason ?? null,
+          status: 'open',
+          posted_at: new Date().toISOString(),
+        })
+        .select()
+        .single();
+
+      if (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to create call-out: ${error.message}`,
+        });
+      }
+
+      // Notify managers about the new call-out
+      const { data: poster } = await ctx.db
+        .from('users')
+        .select('name')
+        .eq('id', ctx.user.id)
+        .single();
+
+      const posterName = poster?.name ?? ctx.user.email;
+
+      const { data: managers } = await ctx.db
+        .from('org_members')
+        .select('user_id')
+        .eq('org_id', ctx.orgId)
+        .in('role', ['manager', 'admin'])
+        .neq('user_id', ctx.user.id);
+
+      if (managers && managers.length > 0) {
+        const message = `${posterName} can't work their shift on ${shift.date} (${shift.start_time} - ${shift.end_time}) and posted a call-out.`;
+
+        for (const manager of managers) {
+          createNotification({
+            db: ctx.db,
+            userId: manager.user_id,
+            type: 'swap_request',
+            title: 'New Call-Out Posted',
+            message,
+            link: '/callouts',
+          }).catch((err) =>
+            console.error('[NOTIFICATION] Failed to notify call-out:', err)
+          );
+        }
+      }
+
+      return { callout };
+    }),
+
+  /**
+   * Cancel an open call-out — only the poster can cancel.
+   */
+  cancel: orgProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const { data: callout, error: fetchError } = await ctx.db
+        .from('callouts')
+        .select('*')
+        .eq('id', input.id)
+        .single();
+
+      if (fetchError || !callout) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Call-out not found',
+        });
+      }
+
+      if (callout.user_id !== ctx.user.id) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You can only cancel your own call-outs',
+        });
+      }
+
+      if (callout.status !== 'open') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Cannot cancel a call-out with status "${callout.status}"`,
+        });
+      }
+
+      const { data: updated, error } = await ctx.db
+        .from('callouts')
+        .update({ status: 'cancelled' })
+        .eq('id', input.id)
+        .select()
+        .single();
+
+      if (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to cancel call-out: ${error.message}`,
+        });
+      }
+
+      return { callout: updated };
+    }),
+});


### PR DESCRIPTION
## Summary
- Staff can now view their upcoming shifts and post a call-out when they can't work
- New `/callouts/new` page with shift selection, optional reason, and confirmation flow
- New `/callouts` page listing all call-outs with status filtering and cancel support
- Full tRPC callout router with list, myShifts, create, and cancel endpoints
- Manager notifications triggered when a call-out is posted

## Test plan
- [ ] Navigate to `/callouts/new` and verify upcoming shifts are displayed
- [ ] Select a shift and submit a call-out — verify it's stored with status='open'
- [ ] Verify the call-out appears on `/callouts` with correct details
- [ ] Verify the "Can't work?" link on dashboard shifts pre-selects the shift
- [ ] Verify shifts with existing callouts are marked and not selectable
- [ ] Verify cancel button works for own open call-outs
- [ ] Verify managers receive in-app notification

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)