### PR TITLE
feat: build Manager Approval UI for shift claims

### DIFF
--- a/src/app/claims/ClaimsList.tsx
+++ b/src/app/claims/ClaimsList.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { trpc } from '@/trpc/client';
+
+interface ClaimShift {
+  id: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+  role: string;
+  department: string;
+  location: { id: string; name: string } | null;
+}
+
+interface ClaimCallout {
+  id: string;
+  status: string;
+  reason: string | null;
+  posted_at: string;
+  shift: ClaimShift | null;
+  user: { id: string; name: string; email: string } | null;
+}
+
+interface ClaimWithDetails {
+  id: string;
+  callout_id: string;
+  user_id: string;
+  status: 'pending' | 'approved' | 'rejected';
+  claimed_at: string;
+  approved_by: string | null;
+  approved_at: string | null;
+  callout: ClaimCallout | null;
+  claimant: { id: string; name: string; email: string } | null;
+}
+
+const STATUS_BADGES: Record<string, { bg: string; text: string; dot: string }> = {
+  pending: { bg: 'bg-amber-50', text: 'text-amber-700', dot: 'bg-amber-400' },
+  approved: { bg: 'bg-emerald-50', text: 'text-emerald-700', dot: 'bg-emerald-400' },
+  rejected: { bg: 'bg-red-50', text: 'text-red-700', dot: 'bg-red-400' },
+};
+
+function formatTime(timeStr: string): string {
+  const [h, m] = timeStr.split(':');
+  const hour = parseInt(h, 10);
+  const ampm = hour >= 12 ? 'PM' : 'AM';
+  const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return `${h12}:${m} ${ampm}`;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const badge = STATUS_BADGES[status] ?? STATUS_BADGES.rejected;
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium border ${badge.bg} ${badge.text} border-current/10`}
+    >
+      <span className={`w-1.5 h-1.5 rounded-full ${badge.dot}`} />
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+type FilterStatus = 'all' | 'pending' | 'approved' | 'rejected';
+
+export function ClaimsList() {
+  const [claims, setClaims] = useState<ClaimWithDetails[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FilterStatus>('all');
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const fetchClaims = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const input = filter === 'all' ? {} : { status: filter as 'pending' | 'approved' | 'rejected' };
+      const result = await trpc.claim.list.query(input);
+      setClaims(result.claims as ClaimWithDetails[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load claims');
+    } finally {
+      setLoading(false);
+    }
+  }, [filter]);
+
+  useEffect(() => {
+    fetchClaims();
+  }, [fetchClaims]);
+
+  const handleApprove = async (claimId: string) => {
+    setActionLoading(claimId);
+    setActionError(null);
+    try {
+      await trpc.claim.approve.mutate({ id: claimId });
+      fetchClaims();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to approve claim');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleReject = async (claimId: string) => {
+    setActionLoading(claimId);
+    setActionError(null);
+    try {
+      await trpc.claim.reject.mutate({ id: claimId });
+      fetchClaims();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to reject claim');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const pendingClaims = claims.filter((c) => c.status === 'pending');
+  const otherClaims = claims.filter((c) => c.status !== 'pending');
+
+  return (
+    <div>
+      {/* Filter controls */}
+      <div className="flex items-center gap-1.5 mb-6 bg-surface-secondary p-1 rounded-xl border border-border-light w-fit">
+        {(['all', 'pending', 'approved', 'rejected'] as FilterStatus[]).map(
+          (status) => (
+            <button
+              key={status}
+              onClick={() => setFilter(status)}
+              className={`px-3.5 py-1.5 rounded-lg text-sm font-medium transition-all ${
+                filter === status
+                  ? 'bg-surface text-text-primary shadow-sm border border-border'
+                  : 'text-text-secondary hover:text-text-primary'
+              }`}
+            >
+              {status === 'all' ? 'All' : status.charAt(0).toUpperCase() + status.slice(1)}
+            </button>
+          )
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm flex items-center gap-2 animate-fade-in-down">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {error}
+          <button onClick={fetchClaims} className="ml-auto text-red-800 underline text-xs font-medium">
+            Retry
+          </button>
+        </div>
+      )}
+
+      {actionError && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm flex items-center gap-2 animate-fade-in-down">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {actionError}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="bg-surface rounded-2xl border border-border p-6"
+            >
+              <div className="flex justify-between items-start">
+                <div className="space-y-2.5 flex-1">
+                  <div className="flex items-center gap-3">
+                    <div className="h-4 w-32 rounded-lg animate-shimmer" />
+                    <div className="h-6 w-20 rounded-lg animate-shimmer" />
+                  </div>
+                  <div className="h-3 w-48 rounded-lg animate-shimmer" />
+                  <div className="h-3 w-24 rounded-lg animate-shimmer" />
+                </div>
+                <div className="flex gap-2">
+                  <div className="h-8 w-20 rounded-xl animate-shimmer" />
+                  <div className="h-8 w-16 rounded-xl animate-shimmer" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <>
+          {/* Pending Approvals Queue */}
+          {pendingClaims.length > 0 && filter === 'all' && (
+            <div className="mb-8 animate-fade-in-up">
+              <h2 className="text-base font-semibold text-text-primary mb-4 flex items-center gap-2">
+                Pending Approvals
+                <span className="px-2 py-0.5 bg-amber-50 text-amber-700 text-xs font-semibold rounded-lg border border-amber-200">
+                  {pendingClaims.length}
+                </span>
+              </h2>
+              <div className="space-y-3">
+                {pendingClaims.map((claim) => (
+                  <ClaimCard
+                    key={claim.id}
+                    claim={claim}
+                    actionLoading={actionLoading === claim.id}
+                    onApprove={() => handleApprove(claim.id)}
+                    onReject={() => handleReject(claim.id)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* All/Filtered Claims */}
+          {(filter === 'all' ? otherClaims : claims).length > 0 ? (
+            <div className="animate-fade-in-up">
+              {pendingClaims.length > 0 && filter === 'all' && (
+                <h2 className="text-base font-semibold text-text-primary mb-4">
+                  History
+                </h2>
+              )}
+              <div className="space-y-3">
+                {(filter === 'all' ? otherClaims : claims).map((claim) => (
+                  <ClaimCard
+                    key={claim.id}
+                    claim={claim}
+                    actionLoading={actionLoading === claim.id}
+                    onApprove={() => handleApprove(claim.id)}
+                    onReject={() => handleReject(claim.id)}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : (
+            filter !== 'all' || pendingClaims.length === 0 ? (
+              <div className="bg-surface rounded-2xl border border-border p-12 text-center">
+                <div className="w-14 h-14 rounded-full bg-surface-secondary flex items-center justify-center mx-auto mb-4">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-text-tertiary">
+                    <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z" />
+                    <path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
+                  </svg>
+                </div>
+                <p className="text-sm text-text-tertiary">No claims found.</p>
+              </div>
+            ) : null
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+interface ClaimCardProps {
+  claim: ClaimWithDetails;
+  actionLoading: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+function ClaimCard({ claim, actionLoading, onApprove, onReject }: ClaimCardProps) {
+  const callout = claim.callout;
+  const shift = callout?.shift;
+  const canAct = claim.status === 'pending';
+
+  const shiftDate = shift
+    ? new Date(shift.date + 'T00:00:00').toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      })
+    : 'Unknown';
+
+  return (
+    <div className="bg-surface rounded-2xl border border-border p-5 hover:shadow-sm transition-all duration-200">
+      <div className="flex justify-between items-start">
+        <div className="flex-1">
+          {/* Claimant info */}
+          <div className="flex items-center gap-3 mb-2">
+            <div className="flex items-center gap-2">
+              <div className="w-7 h-7 rounded-full bg-brand-100 flex items-center justify-center">
+                <span className="text-[10px] font-semibold text-brand-700">
+                  {(claim.claimant?.name ?? '?').charAt(0).toUpperCase()}
+                </span>
+              </div>
+              <span className="text-sm font-semibold text-text-primary">
+                {claim.claimant?.name ?? 'Unknown User'}
+              </span>
+            </div>
+            <StatusBadge status={claim.status} />
+          </div>
+
+          {/* Shift details */}
+          {shift && (
+            <div className="text-sm text-text-secondary mb-1.5 flex items-center gap-1.5">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-text-tertiary shrink-0">
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+              </svg>
+              <span className="font-medium">{shiftDate}</span> &middot;{' '}
+              {formatTime(shift.start_time)} - {formatTime(shift.end_time)} &middot;{' '}
+              <span className="capitalize">{shift.role}</span> &middot;{' '}
+              {shift.department}
+              {shift.location && (
+                <> &middot; {shift.location.name}</>
+              )}
+            </div>
+          )}
+
+          {/* Who called out */}
+          {callout?.user && (
+            <div className="text-sm text-text-secondary mt-1">
+              <span className="font-medium text-text-primary">Called out by:</span>{' '}
+              {callout.user.name}
+            </div>
+          )}
+
+          {/* Callout reason */}
+          {callout?.reason && (
+            <div className="text-sm text-text-secondary mt-1">
+              <span className="font-medium text-text-primary">Reason:</span>{' '}
+              {callout.reason}
+            </div>
+          )}
+
+          {/* Timestamps */}
+          <div className="text-[11px] text-text-tertiary mt-2.5 flex items-center gap-1">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" />
+              <polyline points="12 6 12 12 16 14" />
+            </svg>
+            Claimed{' '}
+            {new Date(claim.claimed_at).toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              hour: 'numeric',
+              minute: '2-digit',
+            })}
+            {claim.approved_at && (
+              <>
+                {' '}&middot; Reviewed{' '}
+                {new Date(claim.approved_at).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                })}
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-2 ml-4">
+          {canAct && (
+            <>
+              <button
+                onClick={onApprove}
+                disabled={actionLoading}
+                className="inline-flex items-center gap-1.5 px-3.5 py-2 bg-emerald-600 hover:bg-emerald-700 disabled:bg-emerald-400 text-white rounded-xl text-sm font-medium transition-all shadow-sm hover:shadow-md active:scale-[0.98]"
+              >
+                {actionLoading ? (
+                  <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                ) : (
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+                Approve
+              </button>
+              <button
+                onClick={onReject}
+                disabled={actionLoading}
+                className="inline-flex items-center gap-1.5 px-3.5 py-2 bg-red-600 hover:bg-red-700 disabled:bg-red-400 text-white rounded-xl text-sm font-medium transition-all shadow-sm hover:shadow-md active:scale-[0.98]"
+              >
+                Deny
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/claims/page.tsx
+++ b/src/app/claims/page.tsx
@@ -1,0 +1,67 @@
+import { requireAuth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { ClaimsList } from './ClaimsList';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ClaimsPage() {
+  const session = await requireAuth();
+
+  // Admin/manager only — redirect staff to dashboard
+  if (session.role === 'staff') {
+    redirect('/dashboard');
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="bg-surface border-b border-border sticky top-0 z-30 backdrop-blur-xl bg-surface/80">
+        <div className="max-w-7xl mx-auto px-6 py-4 flex justify-between items-center">
+          <div className="flex items-center gap-3">
+            <Link href="/dashboard" className="w-8 h-8 rounded-lg bg-surface-secondary border border-border flex items-center justify-center text-text-tertiary hover:text-text-primary hover:bg-border transition-all">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+            </Link>
+            <h1 className="text-lg font-semibold tracking-tight text-text-primary">Claim Approvals</h1>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/callouts"
+              className="text-sm font-medium text-brand-600 hover:text-brand-700 transition-colors"
+            >
+              Open Shifts
+            </Link>
+            <div className="flex items-center gap-2.5">
+              <div className="w-8 h-8 rounded-full bg-brand-100 flex items-center justify-center">
+                <span className="text-xs font-semibold text-brand-700">
+                  {(session.name || session.email || '?').charAt(0).toUpperCase()}
+                </span>
+              </div>
+              <div className="hidden sm:block">
+                <span className="text-sm font-medium text-text-primary">
+                  {session.name || session.email}
+                </span>
+                <span className="ml-2 px-2 py-0.5 text-[11px] font-medium bg-brand-50 text-brand-700 border border-brand-200 rounded-full">
+                  {session.role}
+                </span>
+              </div>
+            </div>
+            <form action="/auth/logout" method="POST">
+              <button
+                type="submit"
+                className="text-sm text-text-tertiary hover:text-text-primary transition-colors"
+              >
+                Sign out
+              </button>
+            </form>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-6 py-6 animate-fade-in-up">
+        <ClaimsList />
+      </main>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -216,6 +216,15 @@ export default async function DashboardPage() {
             </div>
             <div className="p-6 flex flex-wrap gap-3">
               <Link
+                href="/claims"
+                className="inline-flex items-center gap-2 px-4 py-2.5 bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl text-sm font-medium transition-all duration-200 shadow-sm hover:shadow-md active:scale-[0.98]"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+                Review Claims
+              </Link>
+              <Link
                 href="/swaps"
                 className="inline-flex items-center gap-2 px-4 py-2.5 bg-amber-500 hover:bg-amber-600 text-white rounded-xl text-sm font-medium transition-all duration-200 shadow-sm hover:shadow-md active:scale-[0.98]"
               >

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -196,6 +196,78 @@ export async function notifyCalloutClaimed({
 }
 
 /**
+ * Notify the claimant that their shift claim was approved.
+ */
+export async function notifyClaimApproved({
+  db,
+  claimantId,
+  claimantEmail,
+  shiftDate,
+  shiftStartTime,
+  shiftEndTime,
+}: {
+  db: DbClient;
+  claimantId: string;
+  claimantEmail: string;
+  shiftDate: string;
+  shiftStartTime: string;
+  shiftEndTime: string;
+}): Promise<void> {
+  const message = `Your claim for the shift on ${shiftDate} (${shiftStartTime} - ${shiftEndTime}) has been approved. The shift is now assigned to you.`;
+
+  await createNotification({
+    db,
+    userId: claimantId,
+    type: 'claim_approved',
+    title: 'Claim Approved',
+    message,
+    link: '/claims',
+  });
+
+  await sendEmail(claimantEmail, 'claim_approved' as EmailTemplate, {
+    date: shiftDate,
+    startTime: shiftStartTime,
+    endTime: shiftEndTime,
+  });
+}
+
+/**
+ * Notify the claimant that their shift claim was rejected.
+ */
+export async function notifyClaimRejected({
+  db,
+  claimantId,
+  claimantEmail,
+  shiftDate,
+  shiftStartTime,
+  shiftEndTime,
+}: {
+  db: DbClient;
+  claimantId: string;
+  claimantEmail: string;
+  shiftDate: string;
+  shiftStartTime: string;
+  shiftEndTime: string;
+}): Promise<void> {
+  const message = `Your claim for the shift on ${shiftDate} (${shiftStartTime} - ${shiftEndTime}) has been denied.`;
+
+  await createNotification({
+    db,
+    userId: claimantId,
+    type: 'claim_rejected',
+    title: 'Claim Denied',
+    message,
+    link: '/claims',
+  });
+
+  await sendEmail(claimantEmail, 'claim_rejected' as EmailTemplate, {
+    date: shiftDate,
+    startTime: shiftStartTime,
+    endTime: shiftEndTime,
+  });
+}
+
+/**
  * Notify the requester that their swap was denied.
  */
 export async function notifySwapDenied({

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -10,6 +10,7 @@ import { shiftRouter } from './shift';
 import { swapRouter } from './swap';
 import { notificationRouter } from './notification';
 import { calloutRouter } from './callout';
+import { claimRouter } from './claim';
 
 export const appRouter = router({
   /** Health check — public, no auth required */
@@ -63,6 +64,9 @@ export const appRouter = router({
 
   /** Callout routes (org-scoped) */
   callout: calloutRouter,
+
+  /** Claim approval routes (org-scoped) */
+  claim: claimRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/routers/claim.ts
+++ b/src/server/routers/claim.ts
@@ -1,0 +1,283 @@
+/**
+ * Claim router — handles manager approval workflow for shift claims.
+ *
+ * Managers see all pending claims and can approve or reject them.
+ * On approve: claim→approved, callout→approved, shift reassigned, other claims rejected.
+ * On reject: claim→rejected, callout reverted to 'open' if no other pending claims.
+ */
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { router, orgProcedure } from '../trpc';
+import {
+  notifyClaimApproved,
+  notifyClaimRejected,
+} from '@/lib/notifications';
+
+export const claimRouter = router({
+  /**
+   * List claims with full details: callout, shift (incl. location), claimant user, caller user.
+   * - Staff see only their own claims.
+   * - Managers/admins see all claims in the org.
+   * Optionally filter by status. Ordered by most recent first.
+   */
+  list: orgProcedure
+    .input(
+      z.object({
+        status: z.enum(['pending', 'approved', 'rejected']).optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      let query = ctx.db
+        .from('claims')
+        .select(
+          '*, callout:callouts(*, shift:shifts(*, location:locations(id, name)), user:users(id, name, email)), claimant:users!claims_user_id_fkey(id, name, email)'
+        );
+
+      if (input.status) {
+        query = query.eq('status', input.status);
+      }
+
+      // Staff only see their own claims
+      if (ctx.orgRole === 'staff') {
+        query = query.eq('user_id', ctx.user.id);
+      }
+
+      query = query.order('claimed_at', { ascending: false });
+
+      const { data: claims, error } = await query;
+      if (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to fetch claims: ${error.message}`,
+        });
+      }
+      return { claims: claims ?? [] };
+    }),
+
+  /**
+   * Approve a pending claim — manager/admin only.
+   *
+   * 1. Set claim status='approved', approved_by, approved_at
+   * 2. Set callout status='approved'
+   * 3. Reassign the shift to the claimant
+   * 4. Reject all other pending claims for this callout
+   * 5. Notify the claimant
+   */
+  approve: orgProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      if (ctx.orgRole === 'staff') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only managers and admins can approve claims',
+        });
+      }
+
+      // Fetch the claim with callout and shift details
+      const { data: claim, error: fetchError } = await ctx.db
+        .from('claims')
+        .select('*, callout:callouts(*, shift:shifts(*))')
+        .eq('id', input.id)
+        .single();
+
+      if (fetchError || !claim) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Claim not found',
+        });
+      }
+
+      if (claim.status !== 'pending') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Cannot approve a claim with status "${claim.status}"`,
+        });
+      }
+
+      const callout = claim.callout;
+      const shift = callout?.shift;
+
+      if (!callout || !shift) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Claim is missing callout or shift data',
+        });
+      }
+
+      // 1. Approve the claim
+      const { data: updatedClaim, error: approveError } = await ctx.db
+        .from('claims')
+        .update({
+          status: 'approved',
+          approved_by: ctx.user.id,
+          approved_at: new Date().toISOString(),
+        })
+        .eq('id', input.id)
+        .select()
+        .single();
+
+      if (approveError) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to approve claim: ${approveError.message}`,
+        });
+      }
+
+      // 2. Update callout status to 'approved'
+      const { error: calloutError } = await ctx.db
+        .from('callouts')
+        .update({ status: 'approved', updated_at: new Date().toISOString() })
+        .eq('id', claim.callout_id);
+
+      if (calloutError) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to update callout status: ${calloutError.message}`,
+        });
+      }
+
+      // 3. Reassign the shift to the claimant
+      const { error: shiftError } = await ctx.db
+        .from('shifts')
+        .update({ user_id: claim.user_id, updated_at: new Date().toISOString() })
+        .eq('id', shift.id);
+
+      if (shiftError) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to reassign shift: ${shiftError.message}`,
+        });
+      }
+
+      // 4. Reject all other pending claims for this callout
+      const { error: rejectOthersError } = await ctx.db
+        .from('claims')
+        .update({ status: 'rejected' })
+        .eq('callout_id', claim.callout_id)
+        .eq('status', 'pending')
+        .neq('id', input.id);
+
+      if (rejectOthersError) {
+        console.error('[CLAIM] Failed to reject other claims:', rejectOthersError.message);
+      }
+
+      // 5. Notify the claimant
+      const { data: claimant } = await ctx.db
+        .from('users')
+        .select('name, email')
+        .eq('id', claim.user_id)
+        .single();
+
+      notifyClaimApproved({
+        db: ctx.db,
+        claimantId: claim.user_id,
+        claimantEmail: claimant?.email ?? '',
+        shiftDate: shift.date,
+        shiftStartTime: shift.start_time,
+        shiftEndTime: shift.end_time,
+      }).catch((err) =>
+        console.error('[NOTIFICATION] Failed to notify claim approved:', err)
+      );
+
+      return { claim: updatedClaim };
+    }),
+
+  /**
+   * Reject a pending claim — manager/admin only.
+   *
+   * 1. Set claim status='rejected'
+   * 2. If no other pending claims exist for this callout, revert callout to 'open'
+   * 3. Notify the claimant
+   */
+  reject: orgProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      if (ctx.orgRole === 'staff') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only managers and admins can reject claims',
+        });
+      }
+
+      // Fetch the claim with callout and shift details
+      const { data: claim, error: fetchError } = await ctx.db
+        .from('claims')
+        .select('*, callout:callouts(*, shift:shifts(*))')
+        .eq('id', input.id)
+        .single();
+
+      if (fetchError || !claim) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Claim not found',
+        });
+      }
+
+      if (claim.status !== 'pending') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Cannot reject a claim with status "${claim.status}"`,
+        });
+      }
+
+      const callout = claim.callout;
+      const shift = callout?.shift;
+
+      // 1. Reject the claim
+      const { data: updatedClaim, error: rejectError } = await ctx.db
+        .from('claims')
+        .update({ status: 'rejected' })
+        .eq('id', input.id)
+        .select()
+        .single();
+
+      if (rejectError) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to reject claim: ${rejectError.message}`,
+        });
+      }
+
+      // 2. Check if there are other pending claims for this callout
+      const { data: otherPending } = await ctx.db
+        .from('claims')
+        .select('id')
+        .eq('callout_id', claim.callout_id)
+        .eq('status', 'pending')
+        .neq('id', input.id);
+
+      // If no other pending claims, revert callout to 'open'
+      if (!otherPending || otherPending.length === 0) {
+        const { error: calloutError } = await ctx.db
+          .from('callouts')
+          .update({ status: 'open', updated_at: new Date().toISOString() })
+          .eq('id', claim.callout_id);
+
+        if (calloutError) {
+          console.error('[CLAIM] Failed to revert callout to open:', calloutError.message);
+        }
+      }
+
+      // 3. Notify the claimant
+      if (shift) {
+        const { data: claimant } = await ctx.db
+          .from('users')
+          .select('name, email')
+          .eq('id', claim.user_id)
+          .single();
+
+        notifyClaimRejected({
+          db: ctx.db,
+          claimantId: claim.user_id,
+          claimantEmail: claimant?.email ?? '',
+          shiftDate: shift.date,
+          shiftStartTime: shift.start_time,
+          shiftEndTime: shift.end_time,
+        }).catch((err) =>
+          console.error('[NOTIFICATION] Failed to notify claim rejected:', err)
+        );
+      }
+
+      return { claim: updatedClaim };
+    }),
+});

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -75,7 +75,7 @@ export interface SwapRequest {
   updated_at: string;
 }
 
-export type NotificationType = 'swap_request' | 'swap_approved' | 'swap_denied' | 'callout_claimed';
+export type NotificationType = 'swap_request' | 'swap_approved' | 'swap_denied' | 'callout_claimed' | 'claim_approved' | 'claim_rejected';
 
 export interface Notification {
   id: string;


### PR DESCRIPTION
Closes #59

## Summary
- Adds manager/admin-only `/claims` page with one-click approve/deny workflow for pending shift claims
- Creates `claim` tRPC router with `list`, `approve`, and `reject` endpoints, with full business logic:
  - **Approve**: updates claim status, sets callout to 'approved', reassigns shift to claimant, auto-rejects other pending claims, notifies claimant
  - **Deny**: updates claim status, reverts callout to 'open' if no other pending claims remain, notifies claimant
- Adds `ClaimsList` client component with filter tabs (All/Pending/Approved/Rejected), pending approvals queue, loading skeletons, and error handling
- Adds claim notification helpers (`notifyClaimApproved`, `notifyClaimRejected`) with email stubs
- Adds "Review Claims" button to dashboard Manager Actions section
- Follows existing patterns (SwapRequestsList, DESIGN-SYSTEM.md, Geist design system)

## Test plan
- [ ] Verify `/claims` page redirects staff users to `/dashboard`
- [ ] Verify managers/admins can see all pending claims
- [ ] Verify approve sets claim→approved, callout→approved, shift reassigned
- [ ] Verify deny sets claim→rejected, callout reverted to open when no other pending claims
- [ ] Verify filter tabs correctly filter by status
- [ ] Verify "Review Claims" link appears in dashboard manager actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)